### PR TITLE
The list of callbacks in signals can be changed during emitting

### DIFF
--- a/dasbus/signal.py
+++ b/dasbus/signal.py
@@ -47,7 +47,9 @@ class Signal(object):
 
     def emit(self, *args, **kwargs):
         """Emit a signal with the given arguments."""
-        for callback in self._callbacks:
+        # The list of callbacks can be changed, so
+        # use a copy of the list for the iteration.
+        for callback in self._callbacks.copy():
             callback(*args, **kwargs)
 
     def disconnect(self, callback=None):


### PR DESCRIPTION
Iterate over a copy of a list of callbacks in a signal to avoid exceptions
caused by changes in this list during emitting the signal.