### PR TITLE
Extend arguments of dbus_interface

### DIFF
--- a/dasbus/server/interface.py
+++ b/dasbus/server/interface.py
@@ -27,6 +27,7 @@ import re
 from inspect import Parameter
 from typing import get_type_hints
 
+from dasbus.namespace import get_dbus_name
 from dasbus.signal import Signal
 from dasbus.specification import DBusSpecificationError, DBusSpecification
 from dasbus.typing import get_dbus_type
@@ -120,7 +121,7 @@ class dbus_signal(object):
         raise AttributeError("Can't set DBus signal.")
 
 
-def dbus_interface(interface_name):
+def dbus_interface(interface_name, namespace=()):
     """DBus interface.
 
     A new DBus interface can be defined as:
@@ -135,12 +136,16 @@ def dbus_interface(interface_name):
 
     The XML specification is accessible as:
         Interface.__dbus_xml__
+
+    :param interface_name: a DBus name of the interface
+    :param namespace: a sequence of strings
     """
     def decorated(cls):
-        generator = DBusSpecificationGenerator
-        xml = generator.generate_specification(cls, interface_name)
+        name = get_dbus_name(*namespace, interface_name)
+        xml = DBusSpecificationGenerator.generate_specification(cls, name)
         setattr(cls, DBUS_XML_ATTRIBUTE, xml)
         return cls
+
     return decorated
 
 
@@ -161,10 +166,9 @@ def dbus_class(cls):
     accessible as:
         Class.__dbus_xml__
     """
-    # Get the interface decorator without a name.
-    decorated = dbus_interface(None)
-    # Apply the decorator on the given class.
-    return decorated(cls)
+    xml = DBusSpecificationGenerator.generate_specification(cls)
+    setattr(cls, DBUS_XML_ATTRIBUTE, xml)
+    return cls
 
 
 def get_xml(obj):

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -128,7 +128,7 @@ class InterfaceGeneratorTestCase(unittest.TestCase):
     def test_method(self):
         """Test interface with a method."""
 
-        @dbus_interface("Interface")
+        @dbus_interface("my.example.Interface")
         class MethodClass(object):
 
             def Method1(self):
@@ -146,7 +146,7 @@ class InterfaceGeneratorTestCase(unittest.TestCase):
         expected_xml = '''
         <node>
             <!--Specifies MethodClass-->
-            <interface name="Interface">
+            <interface name="my.example.Interface">
                 <method name="Method1"/>
                 <method name="Method2">
                     <arg direction="in" name="x" type="i"/>
@@ -202,7 +202,7 @@ class InterfaceGeneratorTestCase(unittest.TestCase):
     def test_property(self):
         """Test the interface with a property."""
 
-        @dbus_interface("Interface")
+        @dbus_interface("Interface", namespace=("my", "example"))
         class ReadWritePropertyClass(object):
 
             def __init__(self):
@@ -219,7 +219,7 @@ class InterfaceGeneratorTestCase(unittest.TestCase):
         expected_xml = '''
         <node>
             <!--Specifies ReadWritePropertyClass-->
-            <interface name="Interface">
+            <interface name="my.example.Interface">
                 <property name="Property" type="i" access="readwrite" />
             </interface>
         </node>


### PR DESCRIPTION
Add the namespace argument to the `dbus_interface` decorator, so the interface can
be specified by its name or by its name and a namespace.