### PR TITLE
Remove the error handler

### DIFF
--- a/dasbus/error.py
+++ b/dasbus/error.py
@@ -135,31 +135,18 @@ class GLibErrorHandler(object):
         return exception
 
 
-def dbus_error(error_name, namespace=()):
+def dbus_error(error_name, namespace=(), error_handler=GLibErrorHandler):
     """Define decorated class as a DBus error.
 
     The decorated exception class will be mapped to a DBus error.
 
     :param error_name: a DBus name of the error
     :param namespace: a sequence of strings
+    :param error_handler: an error handler
     :return: a decorator
     """
-    return map_error(get_dbus_name(*namespace, error_name))
+    error_name = get_dbus_name(*namespace, error_name)
 
-
-def dbus_error_by_default(cls):
-    """Define a default DBus error.
-
-    The decorated exception class will be mapped to all unknown DBus errors.
-
-    :param cls: an exception class
-    :return: a decorated class
-    """
-    return map_by_default(cls)
-
-
-def map_error(error_name, error_handler=GLibErrorHandler):
-    """Map decorated exception class to a DBus error."""
     def decorated(cls):
         error_handler.register.map_exception_to_name(cls, error_name)
         return cls
@@ -167,7 +154,14 @@ def map_error(error_name, error_handler=GLibErrorHandler):
     return decorated
 
 
-def map_by_default(cls, error_handler=GLibErrorHandler):
-    """Map decorated exception class to all unknown DBus errors."""
+def dbus_error_by_default(cls, error_handler=GLibErrorHandler):
+    """Define a default DBus error.
+
+    The decorated exception class will be mapped to all unknown DBus errors.
+
+    :param cls: an exception class
+    :param error_handler: an error handler
+    :return: a decorated class
+    """
     error_handler.register.set_default_exception(cls)
     return cls

--- a/dasbus/error.py
+++ b/dasbus/error.py
@@ -20,17 +20,41 @@
 #
 from dasbus.namespace import get_dbus_name
 
-import gi
-gi.require_version("Gio", "2.0")
-gi.require_version("GLib", "2.0")
-from gi.repository import Gio, GLib
-
 __all__ = [
     "dbus_error",
     "dbus_error_by_default",
-    "GLibErrorHandler",
-    "ErrorRegister"
+    "register"
 ]
+
+
+def dbus_error(error_name, namespace=()):
+    """Define decorated class as a DBus error.
+
+    The decorated exception class will be mapped to a DBus error.
+
+    :param error_name: a DBus name of the error
+    :param namespace: a sequence of strings
+    :return: a decorator
+    """
+    error_name = get_dbus_name(*namespace, error_name)
+
+    def decorated(cls):
+        register.map_exception_to_name(cls, error_name)
+        return cls
+
+    return decorated
+
+
+def dbus_error_by_default(cls):
+    """Define a default DBus error.
+
+    The decorated exception class will be mapped to all unknown DBus errors.
+
+    :param cls: an exception class
+    :return: a decorated class
+    """
+    register.set_default_exception(cls)
+    return cls
 
 
 class ErrorRegister(object):
@@ -73,95 +97,5 @@ class ErrorRegister(object):
         return self._map.get(name, self._default_class)
 
 
-class GLibErrorHandler(object):
-    """Class for handling DBus errors based on GLib."""
-
-    # Register of DBus errors.
-    register = ErrorRegister()
-
-    @classmethod
-    def handle_server_error(cls, server, invocation, e):
-        """Handle a local exception on the server side."""
-        server.set_call_error(
-            invocation,
-            cls.register.get_error_name(type(e)),
-            str(e)
-        )
-
-    @classmethod
-    def handle_client_error(cls, client, e):
-        """Handle a remote DBus error on the client side."""
-        raise cls._get_exception(e)
-
-    @classmethod
-    def _get_exception(cls, e):
-        """Get an exception for the remote DBus error."""
-        if not isinstance(e, GLib.Error):
-            return e
-
-        if not Gio.DBusError.is_remote_error(e):
-            return e
-
-        name = Gio.DBusError.get_remote_error(e)
-        if not cls._is_name_registered(name):
-            return e
-
-        message = cls._get_exception_message(name, e.message)
-        return cls._create_exception(name, message, e.domain, e.code)
-
-    @classmethod
-    def _is_name_registered(cls, name):
-        """Is there an exception for the given DBus name?"""
-        return cls.register.get_exception_class(name) is not None
-
-    @staticmethod
-    def _get_exception_message(name, message):
-        """Transform the message of the exception."""
-        prefix = "{}:{}: ".format("GDBus.Error", name)
-
-        if message.startswith(prefix):
-            return message[len(prefix):]
-
-        return message
-
-    @classmethod
-    def _create_exception(cls, name, message, domain, code):
-        """Create an exception from the given parameters."""
-        exception_cls = cls.register.get_exception_class(name)
-        exception = exception_cls(message)
-        exception.dbus_name = name
-        exception.dbus_domain = domain
-        exception.dbus_code = code
-        return exception
-
-
-def dbus_error(error_name, namespace=(), error_handler=GLibErrorHandler):
-    """Define decorated class as a DBus error.
-
-    The decorated exception class will be mapped to a DBus error.
-
-    :param error_name: a DBus name of the error
-    :param namespace: a sequence of strings
-    :param error_handler: an error handler
-    :return: a decorator
-    """
-    error_name = get_dbus_name(*namespace, error_name)
-
-    def decorated(cls):
-        error_handler.register.map_exception_to_name(cls, error_name)
-        return cls
-
-    return decorated
-
-
-def dbus_error_by_default(cls, error_handler=GLibErrorHandler):
-    """Define a default DBus error.
-
-    The decorated exception class will be mapped to all unknown DBus errors.
-
-    :param cls: an exception class
-    :param error_handler: an error handler
-    :return: a decorated class
-    """
-    error_handler.register.set_default_exception(cls)
-    return cls
+# A default register of DBus errors.
+register = ErrorRegister()

--- a/dasbus/error.py
+++ b/dasbus/error.py
@@ -135,7 +135,7 @@ class GLibErrorHandler(object):
         return exception
 
 
-def dbus_error(error_name, namespace):
+def dbus_error(error_name, namespace=()):
     """Define decorated class as a DBus error.
 
     The decorated exception class will be mapped to a DBus error.

--- a/tests/test_dbus.py
+++ b/tests/test_dbus.py
@@ -23,7 +23,7 @@ from unittest.mock import Mock
 
 from dasbus.client.proxy import disconnect_proxy
 from dasbus.connection import AddressedMessageBus
-from dasbus.error import map_error
+from dasbus.error import dbus_error
 from dasbus.server.interface import dbus_interface, dbus_signal
 from dasbus.typing import get_variant, Str, Int, Dict, Variant, List
 
@@ -65,7 +65,7 @@ class run_in_glib(object):
         return create_loop
 
 
-@map_error("my.testing.Error")
+@dbus_error("my.testing.Error")
 class ExampleException(Exception):
     pass
 

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -17,15 +17,9 @@
 # USA
 #
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
-from dasbus.error import ErrorRegister, GLibErrorHandler
-from dasbus.client.handler import GLibClient
-from dasbus.server.handler import GLibServer
-
-import gi
-gi.require_version("Gio", "2.0")
-from gi.repository import Gio
+from dasbus.error import ErrorRegister, dbus_error, dbus_error_by_default
 
 
 class ExceptionA(Exception):
@@ -45,6 +39,30 @@ class ExceptionC(Exception):
 
 class DBusErrorTestCase(unittest.TestCase):
     """Test the DBus error register and handler."""
+
+    @patch("dasbus.error.register", new_callable=ErrorRegister)
+    def test_decorators(self, register):
+        """Test the error decorators."""
+        r = register
+
+        @dbus_error("org.test.ErrorA")
+        class DecoratedA(Exception):
+            pass
+
+        @dbus_error("ErrorB", namespace=("org", "test"))
+        class DecoratedB(Exception):
+            pass
+
+        @dbus_error_by_default
+        class DecoratedC(Exception):
+            pass
+
+        self.assertEqual(r.get_error_name(DecoratedA), "org.test.ErrorA")
+        self.assertEqual(r.get_error_name(DecoratedB), "org.test.ErrorB")
+
+        self.assertEqual(r.get_exception_class("org.test.ErrorA"), DecoratedA)
+        self.assertEqual(r.get_exception_class("org.test.ErrorB"), DecoratedB)
+        self.assertEqual(r.get_exception_class("org.test.ErrorC"), DecoratedC)
 
     def test_error_mapping(self):
         """Test the error mapping."""
@@ -114,121 +132,4 @@ class DBusErrorTestCase(unittest.TestCase):
         )
 
         r.set_default_namespace(None)
-        self.assertEqual(
-            r.get_error_name(ExceptionA),
-            "ExceptionA"
-        )
-
-    def test_get_message(self):
-        """Test the DBus error messages."""
-        h = GLibErrorHandler()
-
-        message = h._get_exception_message(
-            "org.test.Error",
-            "My error message"
-        )
-        self.assertEqual(
-            message,
-            "My error message"
-        )
-
-        message = h._get_exception_message(
-            "org.test.Error",
-            "GDBus.Error:org.test.Error: My error message"
-        )
-        self.assertEqual(
-            message,
-            "My error message"
-        )
-
-        message = h._get_exception_message(
-            "org.test.Error",
-            "GDBus.Error:org.test.ErrorX: My error message"
-        )
-        self.assertEqual(
-            message,
-            "GDBus.Error:org.test.ErrorX: My error message"
-        )
-
-    @patch("dasbus.error.GLibErrorHandler.register",
-           new_callable=ErrorRegister)
-    def test_create_exception(self, register):
-        """Test the exception."""
-        domain = Gio.DBusError.quark()
-
-        h = GLibErrorHandler()
-        h.register.map_exception_to_name(ExceptionA, "org.test.ErrorA")
-
-        e = h._create_exception(
-            "org.test.ErrorA",
-            "My error message.",
-            domain,
-            666
-        )
-        self.assertIsInstance(e, ExceptionA)
-        self.assertEqual(str(e), "My error message.")
-        self.assertEqual(getattr(e, "dbus_name"), "org.test.ErrorA")
-        self.assertEqual(getattr(e, "dbus_domain"), domain)
-        self.assertEqual(getattr(e, "dbus_code"), 666)
-
-    @patch("dasbus.error.GLibErrorHandler.register",
-           new_callable=ErrorRegister)
-    def test_is_name_registered(self, register):
-        """Test the registered name."""
-        h = GLibErrorHandler()
-        h.register.map_exception_to_name(ExceptionA, "org.test.ErrorA")
-
-        self.assertEqual(h._is_name_registered("org.test.ErrorA"), True)
-        self.assertEqual(h._is_name_registered("org.test.ErrorB"), False)
-
-    @patch("dasbus.error.GLibErrorHandler.register",
-           new_callable=ErrorRegister)
-    def test_handle_server_error(self, register):
-        """Test the server error handler."""
-        h = GLibErrorHandler()
-        h.register.map_exception_to_name(
-            ExceptionA,
-            "org.test.ErrorA"
-        )
-
-        invocation = Mock()
-        h.handle_server_error(
-            GLibServer,
-            invocation,
-            ExceptionA("My message")
-        )
-        invocation.return_dbus_error.assert_called_once_with(
-            "org.test.ErrorA",
-            "My message"
-        )
-
-    @patch("dasbus.error.GLibErrorHandler.register",
-           new_callable=ErrorRegister)
-    def test_handle_client_error(self, register):
-        """Test the client error handler."""
-        h = GLibErrorHandler()
-        h.register.set_default_exception(ExceptionA)
-        h.register.map_exception_to_name(ExceptionB, "org.test.ErrorB")
-
-        remote_error = Gio.DBusError.new_for_dbus_error(
-            "org.test.Unknown",
-            "My message."
-        )
-        with self.assertRaises(ExceptionA) as cm:
-            h.handle_client_error(GLibClient, remote_error)
-
-        self.assertEqual(str(cm.exception), "My message.")
-
-        remote_error = Gio.DBusError.new_for_dbus_error(
-            "org.test.ErrorB",
-            "My message."
-        )
-        with self.assertRaises(ExceptionB) as cm:
-            h.handle_client_error(GLibClient, remote_error)
-
-        self.assertEqual(str(cm.exception), "My message.")
-
-        with self.assertRaises(ExceptionC) as cm:
-            h.handle_client_error(GLibClient, ExceptionC("My message."))
-
-        self.assertEqual(str(cm.exception), "My message.")
+        self.assertEqual(r.get_error_name(ExceptionA), "ExceptionA")


### PR DESCRIPTION
Remove the error handler and clean up the error support:

* Extend arguments of `dbus_error`.
* Remove `map_error` and `map_by_default`.
* Remove `GLibErrorHandler.`
* Add a default DBus error.