### PR TITLE
Use the minimal image in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: generic
+language: minimal
 services: docker
 sudo: required
 


### PR DESCRIPTION
Set the language in .travis.yml to minimal to use a minimal image for testing.
It should contain all tools needed for running the docker image.