### PR TITLE
Unwrap DBus values

### DIFF
--- a/dasbus/client/handler.py
+++ b/dasbus/client/handler.py
@@ -508,10 +508,7 @@ class ClientObjectHandler(AbstractClientObjectHandler):
         cls = self._error_register.get_exception_class(name)
         message = self._client.get_remote_error_message(error)
 
-        # Re-raise if we cannot match it to an exception class.
-        if not cls:
-            raise error from None
-
+        # Create a new exception.
         exception = cls(message)
         exception.dbus_name = name
 

--- a/dasbus/server/handler.py
+++ b/dasbus/server/handler.py
@@ -26,7 +26,7 @@ from dasbus.signal import Signal
 from dasbus.error import register
 from dasbus.server.interface import get_xml
 from dasbus.specification import DBusSpecification, DBusSpecificationError
-from dasbus.typing import get_variant
+from dasbus.typing import get_variant, unwrap_variant
 
 import gi
 gi.require_version("Gio", "2.0")
@@ -409,7 +409,7 @@ class ServerObjectHandler(AbstractServerObjectHandler):
             result = self._handle_call(
                 interface_name,
                 method_name,
-                *parameters.unpack()
+                *unwrap_variant(parameters)
             )
         except Exception as error:  # pylint: disable=broad-except
             self._handle_method_error(
@@ -484,7 +484,7 @@ class ServerObjectHandler(AbstractServerObjectHandler):
 
         :param interface_name: an interface name
         :param property_name: a property name
-        :return: a property value
+        :return: a variant with a property value
         """
         member = self._find_member_spec(interface_name, property_name)
 
@@ -501,8 +501,7 @@ class ServerObjectHandler(AbstractServerObjectHandler):
 
         :param interface_name: an interface name
         :param property_name: a property name
-        :param property_value: a property value
-        :return:
+        :param property_value: a variant with a property value
         """
         member = self._find_member_spec(interface_name, property_name)
 
@@ -511,7 +510,7 @@ class ServerObjectHandler(AbstractServerObjectHandler):
                 interface_name, property_name
             ))
 
-        setattr(self._object, property_name, property_value)
+        setattr(self._object, property_name, unwrap_variant(property_value))
 
     def _find_all_properties(self, interface_name):
         """Find all properties of the given interface.

--- a/dasbus/structure.py
+++ b/dasbus/structure.py
@@ -22,8 +22,8 @@ import inspect
 from abc import ABC
 from typing import get_type_hints
 
-from dasbus.typing import get_variant, get_type_arguments, is_base_type, \
-    Structure, Dict, List
+from dasbus.typing import get_variant, get_type_arguments, unwrap_variant, \
+    is_base_type, Structure, List
 
 __all__ = [
     "DBusStructureError",
@@ -95,6 +95,14 @@ class DBusField(object):
         :param value: a value
         """
         setattr(obj, self.data_name, value)
+
+    def set_data_variant(self, obj, variant):
+        """Set the data attribute from a variant.
+
+        :param obj: a data object
+        :param variant: a variant
+        """
+        self.set_data(obj, unwrap_variant(variant))
 
     def get_data(self, obj):
         """Get the data attribute.
@@ -203,7 +211,7 @@ class DBusData(ABC):
         )
 
     @classmethod
-    def from_structure(cls, structure: Dict):
+    def from_structure(cls, structure: Structure):
         """Convert a DBus structure to a data object.
 
         :param structure: a DBus structure
@@ -217,7 +225,7 @@ class DBusData(ABC):
         data = cls()
         fields = get_fields(cls)
 
-        for name, value in structure.items():
+        for name, variant in structure.items():
             field = fields.get(name, None)
 
             if not field:
@@ -225,7 +233,7 @@ class DBusData(ABC):
                     "Field '{}' doesn't exist.".format(name)
                 )
 
-            field.set_data(data, value)
+            field.set_data_variant(data, variant)
 
         return data
 
@@ -249,7 +257,7 @@ class DBusData(ABC):
         return structure
 
     @classmethod
-    def from_structure_list(cls, structures: List[Dict]):
+    def from_structure_list(cls, structures: List[Structure]):
         """Convert DBus structures to data objects.
 
         :param structures: a list of DBus structures

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,15 +23,14 @@ from unittest.mock import Mock
 from dasbus.client.handler import ClientObjectHandler, GLibClient
 from dasbus.client.proxy import ObjectProxy, disconnect_proxy
 from dasbus.constants import DBUS_FLAG_NONE
-from dasbus.error import ErrorRegister
+from dasbus.error import ErrorRegister, DBusError
 from dasbus.signal import Signal
 from dasbus.specification import DBusSpecification
 from dasbus.typing import get_variant, get_variant_type, VariantType
 
 import gi
 gi.require_version("Gio", "2.0")
-gi.require_version("GLib", "2.0")
-from gi.repository import Gio, GLib
+from gi.repository import Gio
 
 
 class FakeException(Exception):
@@ -210,7 +209,7 @@ class DBusClientTestCase(unittest.TestCase):
             "My message."
         ))
 
-        with self.assertRaises(GLib.Error) as cm:
+        with self.assertRaises(DBusError) as cm:
             self.proxy.Method1()
 
         self.assertTrue("My message." in str(cm.exception))

--- a/tests/test_dbus.py
+++ b/tests/test_dbus.py
@@ -476,6 +476,6 @@ class DBusTestCase(unittest.TestCase):
 
         callback.assert_called_once_with(
             "my.testing.Example",
-            {"Value": 10},
+            {"Value": get_variant(Int, 10)},
             ["Name"]
         )

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -19,7 +19,7 @@
 import unittest
 
 from dasbus.typing import get_variant, get_native, Int, Str, List, Bool, \
-    Dict, Structure
+    Dict, Structure, Variant
 from dasbus.structure import DBusData, DBusStructureError, compare_data, \
     generate_string_from_data
 
@@ -105,10 +105,16 @@ class DBusStructureTestCase(unittest.TestCase):
 
     def test_skip_members(self):
         data = self.SkipData()
-        structure = self.SkipData.to_structure(data)
-        self.assertEqual(structure, {'x': get_variant(Int, 0)})
 
-        data = self.SkipData.from_structure({'x': 10})
+        structure = self.SkipData.to_structure(data)
+        self.assertEqual(structure, {
+            'x': get_variant(Int, 0)
+        })
+
+        data = self.SkipData.from_structure({
+            'x': get_variant(Int, 10)
+        })
+
         self.assertEqual(data.x, 10)
 
     class SimpleData(DBusData):
@@ -159,21 +165,21 @@ class DBusStructureTestCase(unittest.TestCase):
         data = self.SimpleData()
         self.assertEqual(data.x, 0)
 
-        structure = {'x': 10}
+        structure = {'x': get_variant(Int, 10)}
         data = self.SimpleData.from_structure(structure)
 
         self.assertEqual(data.x, 10)
 
     def test_apply_simple_invalid_structure(self):
         with self.assertRaises(DBusStructureError) as cm:
-            self.SimpleData.from_structure({'y': 10})
+            self.SimpleData.from_structure({'y': get_variant(Int, 10)})
 
         self.assertEqual(str(cm.exception), "Field 'y' doesn't exist.")
 
     def test_apply_simple_structure_list(self):
-        s1 = {'x': 1}
-        s2 = {'x': 2}
-        s3 = {'x': 3}
+        s1 = {'x': get_variant(Int, 1)}
+        s2 = {'x': get_variant(Int, 2)}
+        s3 = {'x': get_variant(Int, 3)}
 
         data = self.SimpleData.from_structure_list([s1, s2, s3])
 
@@ -192,13 +198,13 @@ class DBusStructureTestCase(unittest.TestCase):
         self.assertFalse(compare_data(None, data))
 
         self.assertTrue(compare_data(
-            self.SimpleData.from_structure({'x': 10}),
-            self.SimpleData.from_structure({'x': 10})
+            self.SimpleData.from_structure({'x': get_variant(Int, 10)}),
+            self.SimpleData.from_structure({'x': get_variant(Int, 10)})
         ))
 
         self.assertFalse(compare_data(
-            self.SimpleData.from_structure({'x': 10}),
-            self.SimpleData.from_structure({'x': 9})
+            self.SimpleData.from_structure({'x': get_variant(Int, 10)}),
+            self.SimpleData.from_structure({'x': get_variant(Int, 9)})
         ))
 
     class OtherData(DBusData):
@@ -269,9 +275,15 @@ class DBusStructureTestCase(unittest.TestCase):
 
         self.assertEqual(
             {
-                'dictionary': get_variant(Dict[Int, Str], {1: "1", 2: "2"}),
-                'bool-list': get_variant(List[Bool], [True, False, False]),
-                'very-long-property-name': get_variant(Str, "My String Value")
+                'dictionary': get_variant(
+                    Dict[Int, Str], {1: "1", 2: "2"}
+                ),
+                'bool-list': get_variant(
+                    List[Bool], [True, False, False]
+                ),
+                'very-long-property-name': get_variant(
+                    Str, "My String Value"
+                )
             },
             self.ComplicatedData.to_structure(data)
         )
@@ -279,9 +291,15 @@ class DBusStructureTestCase(unittest.TestCase):
     def test_apply_complicated_structure(self):
         data = self.ComplicatedData.from_structure(
             {
-                'dictionary': {1: "1", 2: "2"},
-                'bool-list': [True, False, False],
-                'very-long-property-name': "My String Value"
+                'dictionary': get_variant(
+                    Dict[Int, Str], {1: "1", 2: "2"}
+                ),
+                'bool-list': get_variant(
+                    List[Bool], [True, False, False]
+                ),
+                'very-long-property-name': get_variant(
+                    Str, "My String Value"
+                )
             }
         )
 
@@ -308,16 +326,28 @@ class DBusStructureTestCase(unittest.TestCase):
         self.assertTrue(compare_data(
             self.ComplicatedData.from_structure(
                 {
-                    'dictionary': {1: "1", 2: "2"},
-                    'bool-list': [True, False, False],
-                    'very-long-property-name': "My String Value"
+                    'dictionary': get_variant(
+                        Dict[Int, Str], {1: "1", 2: "2"}
+                    ),
+                    'bool-list': get_variant(
+                        List[Bool], [True, False, False]
+                    ),
+                    'very-long-property-name': get_variant(
+                        Str, "My String Value"
+                    )
                 }
             ),
             self.ComplicatedData.from_structure(
                 {
-                    'dictionary': {1: "1", 2: "2"},
-                    'bool-list': [True, False, False],
-                    'very-long-property-name': "My String Value"
+                    'dictionary': get_variant(
+                        Dict[Int, Str], {1: "1", 2: "2"}
+                    ),
+                    'bool-list': get_variant(
+                        List[Bool], [True, False, False]
+                    ),
+                    'very-long-property-name': get_variant(
+                        Str, "My String Value"
+                    )
                 }
             )
         ))
@@ -325,28 +355,54 @@ class DBusStructureTestCase(unittest.TestCase):
         self.assertFalse(compare_data(
             self.ComplicatedData.from_structure(
                 {
-                    'dictionary': {1: "1", 2: "2"},
-                    'bool-list': [True, False, False],
-                    'very-long-property-name': "My String Value"
+                    'dictionary': get_variant(
+                        Dict[Int, Str], {1: "1", 2: "2"}
+                    ),
+                    'bool-list': get_variant(
+                        List[Bool], [True, False, False]
+                    ),
+                    'very-long-property-name': get_variant(
+                        Str, "My String Value"
+                    )
                 }
             ),
             self.ComplicatedData.from_structure(
                 {
-                    'dictionary': {1: "1", 2: "2"},
-                    'bool-list': [True, False, True],
-                    'very-long-property-name': "My String Value"
+                    'dictionary': get_variant(
+                        Dict[Int, Str], {1: "1", 2: "2"}
+                    ),
+                    'bool-list': get_variant(
+                        List[Bool], [True, False, True]
+                    ),
+                    'very-long-property-name': get_variant(
+                        Str, "My String Value"
+                    )
                 }
             )
         ))
 
     def test_get_native_complicated_structure(self):
+        data = self.ComplicatedData.from_structure({
+            'dictionary': get_variant(
+                Dict[Int, Str], {1: "1", 2: "2"}
+            ),
+            'bool-list': get_variant(
+                List[Bool], [True, False, False]
+            ),
+            'very-long-property-name': get_variant(
+                Str, "My String Value"
+            )
+        })
+
+        structure = self.ComplicatedData.to_structure(
+            data
+        )
+
         dictionary = {
             'dictionary': {1: "1", 2: "2"},
             'bool-list': [True, False, False],
             'very-long-property-name': "My String Value"
         }
-        data = self.ComplicatedData.from_structure(dictionary)
-        structure = self.ComplicatedData.to_structure(data)
 
         self.assertEqual(get_native(structure), dictionary)
         self.assertEqual(get_native(dictionary), dictionary)
@@ -527,7 +583,17 @@ class DBusStructureTestCase(unittest.TestCase):
             'list': [{'x': 200}, {'x': 300}]
         }
 
-        data = NestedData.from_structure(dictionary)
+        structure = {
+            'attr': get_variant(Dict[Str, Variant], {
+                'x': get_variant(Int, 10)
+            }),
+            'list': get_variant(List[Dict[Str, Variant]], [
+                {'x': get_variant(Int, 200)},
+                {'x': get_variant(Int, 300)}
+            ])
+        }
+
+        data = NestedData.from_structure(structure)
         self.assertEqual(data.attr.x, 10)
         self.assertEqual(len(data.list), 2)
         self.assertEqual(data.list[0].x, 200)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -23,7 +23,8 @@ from typing import Set
 
 from dasbus.typing import get_dbus_type, is_base_type, get_native, \
     get_variant, get_variant_type, Int, Int16, Int32, Int64, UInt16, UInt32, \
-    UInt64, Bool, Byte, Str, Dict, List, Tuple, Variant, Double, ObjPath, File
+    UInt64, Bool, Byte, Str, Dict, List, Tuple, Variant, Double, ObjPath, \
+    File, unwrap_variant
 
 import gi
 gi.require_version("GLib", "2.0")
@@ -207,6 +208,7 @@ class DBusTypingVariantTests(unittest.TestCase):
         self.assertTrue(isinstance(v1, Variant))
         self.assertEqual(v1.format_string, expected_string)
         self.assertEqual(v1.unpack(), value)
+        self.assertEqual(unwrap_variant(v1), value)
 
         v2 = Variant(expected_string, value)
         self.assertTrue(v2.equal(v1))
@@ -276,6 +278,24 @@ class DBusTypingVariantTests(unittest.TestCase):
         self.assertEqual(get_native(list(variants)), list(values))
         self.assertEqual(get_native(dict(enumerate(variants))),
                          dict(enumerate(values)))
+
+        variant = get_variant(
+            Tuple[Variant, Variant, Variant, Variant],
+            tuple(variants)
+        )
+        self.assertEqual(unwrap_variant(variant), tuple(variants))
+
+        variant = get_variant(
+            List[Variant],
+            list(variants)
+        )
+        self.assertEqual(unwrap_variant(variant), list(variants))
+
+        variant = get_variant(
+            Dict[Int, Variant],
+            dict(enumerate(variants))
+        )
+        self.assertEqual(unwrap_variant(variant), dict(enumerate(variants)))
 
     def test_basic_native(self):
         """Test get_native with basic variants."""


### PR DESCRIPTION
Call the function unwrap_variant to unwrap a variant data type. Unlike
the unpack method of the Variant class, this function doesn't recursively
unpacks all variants in the data structure. It will unpack only the topmost
variant.

The real data types of DBus values don't have to match the DBus types declared
in DBus interfaces and structures, because all variants are replaced with their
values. It is caused by unpacking the received DBus values. Let's unwrap them
instead.

Add the commit removed from https://github.com/rhinstaller/dasbus/pull/11.

**This PR requires changes in the Anaconda Installer.**