### PR TITLE
Check the list of DBus structures to convert

### DIFF
--- a/dasbus/structure.py
+++ b/dasbus/structure.py
@@ -263,6 +263,11 @@ class DBusData(ABC):
         :param structures: a list of DBus structures
         :return: a list of data objects
         """
+        if not isinstance(structures, list):
+            raise TypeError(
+                "Invalid type '{}'.".format(type(structures).__name__)
+            )
+
         return list(map(cls.from_structure, structures))
 
     @classmethod

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -236,6 +236,14 @@ class DBusStructureTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception), "Invalid type 'list'.")
 
+    def test_apply_structure_with_invalid_type_variant(self):
+        structure = get_variant(List[Structure], [{'x': get_variant(Int, 10)}])
+
+        with self.assertRaises(TypeError) as cm:
+            self.SimpleData.from_structure_list(structure)
+
+        self.assertEqual(str(cm.exception), "Invalid type 'Variant'.")
+
     class ComplicatedData(DBusData):
 
         def __init__(self):


### PR DESCRIPTION
The conversion should fail sooner if we try to convert a variant of
a list of structures, so make sure that the given value is a list.

Related: rhbz#1798392