### PR TITLE
Replace the error register with the error mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,14 @@ print(proxy.NetworkingEnabled)
 Use exceptions to propagate and handle DBus errors.
 
 ```python
-from dasbus.error import dbus_error, DBusError
+from dasbus.error import ErrorMapper
+error_mapper = ErrorMapper()
+
+from dasbus.connection import SessionMessageBus
+bus = SessionMessageBus(error_mapper=error_mapper)
+
+from dasbus.error import DBusError, get_error_decorator
+dbus_error = get_error_decorator(error_mapper)
 
 @dbus_error("org.freedesktop.DBus.Error.InvalidArgs")
 class InvalidArgs(DBusError):

--- a/dasbus/client/proxy.py
+++ b/dasbus/client/proxy.py
@@ -79,15 +79,21 @@ class AbstractObjectProxy(ABC):
     _locals = {*__slots__}
 
     def __init__(self, message_bus, service_name, object_path,
-                 handler_factory=ClientObjectHandler):
+                 handler_factory=ClientObjectHandler, **handler_arguments):
         """Create a new proxy.
 
         :param message_bus: a message bus
         :param service_name: a DBus name of the service
         :param object_path: a DBus path the object
         :param handler_factory: a factory of a DBus client object handler
+        :param handler_arguments: additional arguments for the handler factory
         """
-        self._handler = handler_factory(message_bus, service_name, object_path)
+        self._handler = handler_factory(
+            message_bus,
+            service_name,
+            object_path,
+            **handler_arguments
+        )
         self._members = dict()
         self._lock = Lock()
 

--- a/dasbus/connection.py
+++ b/dasbus/connection.py
@@ -295,12 +295,12 @@ class SessionMessageBus(MessageBus):
 class AddressedMessageBus(MessageBus):
     """Representation of a connection for the specified address."""
 
-    def __init__(self, address):
+    def __init__(self, address, *args, **kwargs):
         """Create a new representation of a connection.
 
         :param address: a bus address
         """
-        super().__init__()
+        super().__init__(*args, **kwargs)
         self._address = address
 
     @property

--- a/dasbus/error.py
+++ b/dasbus/error.py
@@ -18,32 +18,64 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 # USA
 #
+from abc import ABC, abstractmethod
+
 from dasbus.namespace import get_dbus_name
 
 __all__ = [
-    "dbus_error",
+    "get_error_decorator",
     "DBusError",
-    "register",
-    "ErrorRegister"
+    "AbstractErrorRule",
+    "ErrorRule",
+    "DefaultErrorRule",
+    "ErrorMapper"
 ]
 
 
-def dbus_error(error_name, namespace=()):
-    """Define decorated class as a DBus error.
+def get_error_decorator(error_mapper):
+    """Generate a decorator for DBus errors.
 
-    The decorated exception class will be mapped to a DBus error.
+    Create a function for decorating Python exception classes.
+    The decorator will add a new rule to the given error mapper
+    that will map the class to the specified error name.
 
-    :param error_name: a DBus name of the error
-    :param namespace: a sequence of strings
+    Definition of the decorator:
+
+        decorator(error_name, namespace=())
+
+    The decorator accepts a name of the DBus error and optionally
+    a namespace of the DBus name. The namespace will be used as
+    a prefix of the DBus name.
+
+    Usage:
+
+        # Create an error mapper.
+        error_mapper = ErrorMapper()
+
+        # Create a decorator for DBus errors and use it to map
+        # the class ExampleError to the name my.example.Error.
+        dbus_error = create_error_decorator(error_mapper)
+
+        @dbus_error("my.example.Error")
+        class ExampleError(DBusError):
+            pass
+
+    :param error_mapper: an error mapper
     :return: a decorator
     """
-    error_name = get_dbus_name(*namespace, error_name)
+    def decorator(error_name, namespace=()):
+        error_name = get_dbus_name(*namespace, error_name)
 
-    def decorated(cls):
-        register.map_exception_to_name(cls, error_name)
-        return cls
+        def decorated(cls):
+            error_mapper.add_rule(ErrorRule(
+                exception_type=cls,
+                error_name=error_name
+            ))
+            return cls
 
-    return decorated
+        return decorated
+
+    return decorator
 
 
 class DBusError(Exception):
@@ -51,35 +83,206 @@ class DBusError(Exception):
     pass
 
 
-class ErrorRegister(object):
-    """Class for mapping exceptions to DBus errors."""
+class AbstractErrorRule(ABC):
+    """Abstract rule for mapping a Python exception to a DBus error."""
 
-    def __init__(self, default_namespace="not.known.Error",
-                 default_class=DBusError):
-        self._default_class = default_class
+    __slots__ = []
+
+    @abstractmethod
+    def match_type(self, exception_type):
+        """Is this rule matching the given exception type?
+
+        :param exception_type: a type of the Python error
+        :return: True or False
+        """
+        pass
+
+    @abstractmethod
+    def get_name(self, exception_type):
+        """Get a DBus name for the given exception type.
+
+        :param exception_type: a type of the Python error
+        :return: a name of the DBus error
+        """
+        pass
+
+    @abstractmethod
+    def match_name(self, error_name):
+        """Is this rule matching the given DBus error?
+
+        :param error_name: a name of the DBus error
+        :return: True or False
+        """
+        pass
+
+    @abstractmethod
+    def get_type(self, error_name):
+        """Get an exception type of the given DBus error.
+
+        param error_name: a name of the DBus error
+        :return: a type of the Python error
+        """
+        pass
+
+
+class ErrorRule(AbstractErrorRule):
+    """Rule for mapping a Python exception to a DBus error."""
+
+    __slots__ = [
+        "_exception_type",
+        "_error_name"
+    ]
+
+    def __init__(self, exception_type, error_name):
+        """Create a new error rule.
+
+        The rule will return the Python type exception_type
+        for the the DBue error error_name.
+
+        The rule will return the DBue name error_name for
+        the Python type exception_type
+
+        :param exception_type: a type of the Python error
+        :param error_name: a name of the DBus error
+        """
+        self._exception_type = exception_type
+        self._error_name = error_name
+
+    def match_type(self, exception_type):
+        """Is this rule matching the given exception type?"""
+        return self._exception_type == exception_type
+
+    def get_name(self, exception_type):
+        """Get a DBus name for the given exception type."""
+        return self._error_name
+
+    def match_name(self, error_name):
+        """Is this rule matching the given DBus error?"""
+        return self._error_name == error_name
+
+    def get_type(self, error_name):
+        """Get an exception type of the given DBus error."""
+        return self._exception_type
+
+
+class DefaultErrorRule(AbstractErrorRule):
+    """Default rule for mapping a Python exception to a DBus error."""
+
+    __slots__ = [
+        "_default_type",
+        "_default_namespace"
+    ]
+
+    def __init__(self, default_type, default_namespace):
+        """Create a new default rule.
+
+        The rule will return the Python type default_type
+        for the all DBus errors.
+
+        The rule will generate a DBus name with the prefix
+        default_namespace for all Python exception types.
+
+        :param default_type: a default type of the Python error
+        :param default_namespace: a default namespace of the DBus error
+        """
+        self._default_type = default_type
         self._default_namespace = default_namespace
-        self._map = dict()
-        self._reversed_map = dict()
 
-    def map_exception_to_name(self, exception_cls, name):
-        """Map the exception class to a DBus name."""
-        self._map[name] = exception_cls
-        self._reversed_map[exception_cls] = name
+    def match_type(self, exception_type):
+        """Is this rule matching the given exception type?"""
+        return True
 
-    def get_error_name(self, exception_cls):
-        """Get the DBus name of the exception."""
-        if exception_cls in self._reversed_map:
-            return self._reversed_map.get(exception_cls)
+    def get_name(self, exception_type):
+        """Get a DBus name for the given exception type."""
+        return get_dbus_name(*self._default_namespace, exception_type.__name__)
 
-        return "{}.{}".format(
-            self._default_namespace,
-            exception_cls.__name__
+    def match_name(self, error_name):
+        """Is this rule matching the given DBus error?"""
+        return True
+
+    def get_type(self, error_name):
+        """Get an exception type of the given DBus error."""
+        return self._default_type
+
+
+class ErrorMapper(object):
+    """Class for mapping Python exceptions to DBus errors."""
+
+    __slots__ = ["_error_rules"]
+
+    def __init__(self):
+        """Create a new error mapper."""
+        self._error_rules = []
+        self.reset_rules()
+
+    def add_rule(self, rule: AbstractErrorRule):
+        """Add a rule to the error mapper.
+
+        The new rule will have a higher priority than
+        the rules already contained in the error mapper.
+
+        :param rule: an error rule
+        :type rule: an instance of AbstractErrorRule
+        """
+        self._error_rules.append(rule)
+
+    def reset_rules(self):
+        """Reset rules in the error mapper.
+
+        Reset the error rules to the initial state.
+        All rules will be replaced with the default ones.
+        """
+        # Clear the list.
+        self._error_rules = []
+
+        # Add the default rules.
+        self.add_rule(DefaultErrorRule(
+            default_type=DBusError,
+            default_namespace=("not", "known", "Error")
+        ))
+
+    def get_error_name(self, exception_type):
+        """Get a DBus name of the Python exception.
+
+        Try to find a matching rule in the error mapper.
+        If a rule matches the given exception type, use
+        the rule to get the name of the DBus error.
+
+        The rules in the error mapper are processed in
+        the reversed order to respect the priority of
+        the rules.
+
+        :param exception_type: a type of the Python error
+        :type exception_type: a subclass of Exception
+        :return: a name of the DBus error
+        :raise LookupError: if no name is found
+        """
+        for rule in reversed(self._error_rules):
+            if rule.match_type(exception_type):
+                return rule.get_name(exception_type)
+
+        raise LookupError(
+            "No name found for '{}'.".format(exception_type.__name__)
         )
 
-    def get_exception_class(self, name):
-        """Get the exception class mapped to the DBus name."""
-        return self._map.get(name, self._default_class)
+    def get_exception_type(self, error_name):
+        """Get a Python exception type of the DBus error.
 
+        Try to find a matching rule in the error mapper.
+        If a rule matches the given name of a DBus error,
+        use the rule to get the type of a Python exception.
 
-# A default register of DBus errors.
-register = ErrorRegister()
+        The rules in the error mapper are processed in
+        the reversed order to respect the priority of
+        the rules.
+
+        :param error_name: a name of the DBus error
+        :return: a type of the Python exception
+        :rtype: a subclass of Exception
+        :raise LookupError: if no type is found
+        """
+        for rule in reversed(self._error_rules):
+            if rule.match_name(error_name):
+                return rule.get_type(error_name)
+
+        raise LookupError("No type found for '{}'.".format(error_name))

--- a/examples/04_register/common.py
+++ b/examples/04_register/common.py
@@ -2,13 +2,18 @@
 # The common definitions
 #
 from dasbus.connection import SessionMessageBus
-from dasbus.error import dbus_error, DBusError
+from dasbus.error import DBusError, ErrorMapper, get_error_decorator
 from dasbus.identifier import DBusServiceIdentifier
 from dasbus.structure import DBusData
 from dasbus.typing import Str, Int
 
+# Define the error mapper.
+ERROR_MAPPER = ErrorMapper()
+
 # Define the message bus.
-SESSION_BUS = SessionMessageBus()
+SESSION_BUS = SessionMessageBus(
+    error_mapper=ERROR_MAPPER
+)
 
 # Define namespaces.
 REGISTER_NAMESPACE = ("org", "example", "Register")
@@ -18,6 +23,9 @@ REGISTER = DBusServiceIdentifier(
     namespace=REGISTER_NAMESPACE,
     message_bus=SESSION_BUS
 )
+
+# The decorator for DBus errors.
+dbus_error = get_error_decorator(ERROR_MAPPER)
 
 
 # Define errors.

--- a/tests/test_dbus.py
+++ b/tests/test_dbus.py
@@ -23,7 +23,7 @@ from unittest.mock import Mock
 
 from dasbus.client.proxy import disconnect_proxy
 from dasbus.connection import AddressedMessageBus
-from dasbus.error import dbus_error
+from dasbus.error import ErrorMapper, get_error_decorator
 from dasbus.loop import EventLoop
 from dasbus.server.interface import dbus_interface, dbus_signal
 from dasbus.typing import get_variant, Str, Int, Dict, Variant, List
@@ -32,6 +32,10 @@ import gi
 gi.require_version("Gio", "2.0")
 gi.require_version("GLib", "2.0")
 from gi.repository import Gio, GLib
+
+# Define the error mapper and decorator.
+error_mapper = ErrorMapper()
+dbus_error = get_error_decorator(error_mapper)
 
 
 class run_in_glib(object):
@@ -136,7 +140,10 @@ class DBusTestCase(unittest.TestCase):
     def setUp(self):
         self.bus = Gio.TestDBus()
         self.bus.up()
-        self.message_bus = AddressedMessageBus(self.bus.get_bus_address())
+        self.message_bus = AddressedMessageBus(
+            self.bus.get_bus_address(),
+            error_mapper=error_mapper
+        )
 
         self.service = None
         self.clients = []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -20,7 +20,7 @@ import unittest
 from textwrap import dedent
 from unittest.mock import Mock
 
-from dasbus.error import ErrorRegister
+from dasbus.error import ErrorMapper, ErrorRule
 from dasbus.server.handler import ServerObjectHandler, GLibServer
 from dasbus.signal import Signal
 from dasbus.specification import DBusSpecificationError
@@ -40,7 +40,7 @@ class DBusServerTestCase(unittest.TestCase):
     def setUp(self):
         self.message_bus = Mock()
         self.connection = self.message_bus.connection
-        self.register = ErrorRegister()
+        self.error_mapper = ErrorMapper()
         self.object = None
         self.object_path = "/my/path"
         self.handler = None
@@ -65,7 +65,7 @@ class DBusServerTestCase(unittest.TestCase):
             self.message_bus,
             self.object_path,
             self.object,
-            error_register=self.register
+            error_mapper=self.error_mapper
         )
         self.handler.connect_object()
 
@@ -175,10 +175,10 @@ class DBusServerTestCase(unittest.TestCase):
                           "the interface Interface."
         )
 
-        self.register.map_exception_to_name(
-            MethodFailedException,
-            "MethodFailed"
-        )
+        self.error_mapper.add_rule(ErrorRule(
+            exception_type=MethodFailedException,
+            error_name="MethodFailed"
+        ))
 
         self.object.Method1.side_effect = MethodFailedException(
             "The method has failed."


### PR DESCRIPTION
At this moment, all DBus errors are registered with the global error register.
It works fine until you import a third-party module that also uses dasbus and
its error registration. If the registered errors are overlapping, the register
can start to produce unexpected results.

To avoid this problem, it is necessary to remove this global variable from
dasbus. You should create your own instance of the error mapper, assign it to
your message bus and use it for your error registration.

The class ErrorMapper provides the implementation of the error mapper. The
mapper operates with a list of rules that specify the mapping between Python
exception types and DBus error names. The rules are represented by instances
of the classes ErrorRule and DefaultErrorRule.

Call the function get_error_decorator to generate a decorator for DBus errors.