### PR TITLE
Update the documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,12 @@
+# Read the Docs configuration file
+# See: https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+# The version of the configuration file.
+version: 2
+
+# Formats of the documentation to be built.
+formats: all
+
+# Configuration for Conda support.
+conda:
+  environment: docs/environment.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
   # Run tests in the running container.
   - docker exec "$(cat container_id)" make check
   - docker exec "$(cat container_id)" make coverage
+  - docker exec "$(cat container_id)" make docs
 
 after_script:
   # Stop the container.

--- a/.travis/Dockerfile.fedora-rawhide
+++ b/.travis/Dockerfile.fedora-rawhide
@@ -6,8 +6,10 @@ RUN dnf -y install \
     python3 \
     python3-pip \
     python3-gobject-base \
+    python3-sphinx \
     dbus-daemon
 
 RUN pip3 install \
+    sphinx_rtd_theme \
     coverage \
     pylint

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ coverage:
 	PYTHONPATH=. $(COVERAGE) run --branch -m unittest discover -v -s tests/
 	$(COVERAGE) report -m --include="dasbus/*" | tee coverage-report.log
 
+.PHONY: docs
+docs:
+	$(MAKE) -C docs html text
+
 .PHONY: changelog
 changelog:
 	@git log --no-merges --pretty="format:- %s (%ae)" $(TAG).. | sed -e 's/@.*)/)/'

--- a/dasbus/client/observer.py
+++ b/dasbus/client/observer.py
@@ -111,23 +111,26 @@ class DBusObserver(object):
 
     Usage:
 
-    # Create the observer and connect to its signals.
-    observer = DBusObserver(SystemBus, "org.freedesktop.NetworkManager")
+    .. code-block:: python
 
-    def callback1(observer):
-        print("Service is available!")
+        # Create the observer and connect to its signals.
+        observer = DBusObserver(SystemBus, "org.freedesktop.NetworkManager")
 
-    def callback2(observer):
-        print("Service is unavailable!")
+        def callback1(observer):
+            print("Service is available!")
 
-    observer.service_available.connect(callback1)
-    observer.service_unavailable.connect(callback2)
+        def callback2(observer):
+            print("Service is unavailable!")
 
-    # Connect to the service once it is available.
-    # observer.connect_once_available()
+        observer.service_available.connect(callback1)
+        observer.service_unavailable.connect(callback2)
 
-    # Disconnect the observer.
-    observer.disconnect()
+        # Connect to the service once it is available.
+        # observer.connect_once_available()
+
+        # Disconnect the observer.
+        observer.disconnect()
+
     """
 
     def __init__(self, message_bus, service_name, monitoring=GLibMonitoring):

--- a/dasbus/loop.py
+++ b/dasbus/loop.py
@@ -38,13 +38,16 @@ class AbstractEventLoop(ABC):
 
     Example:
 
-    # Create the event loop.
-    loop = EventLoop()
+    .. code-block:: python
 
-    # Start the event loop.
-    loop.run()
+        # Create the event loop.
+        loop = EventLoop()
 
-    # Run loop.quit() to stop.
+        # Start the event loop.
+        loop.run()
+
+        # Run loop.quit() to stop.
+
     """
 
     @abstractmethod

--- a/dasbus/server/container.py
+++ b/dasbus/server/container.py
@@ -43,18 +43,20 @@ class DBusContainer(object):
 
     Example:
 
-    # Create a container of tasks.
-    container = DBusContainer(
-        namespace=("my", "project"),
-        basename="Task",
-        message_bus=DBus
-    )
+    .. code-block:: python
 
-    # Publish a task.
-    path = container.to_object_path(MyTask())
+        # Create a container of tasks.
+        container = DBusContainer(
+            namespace=("my", "project"),
+            basename="Task",
+            message_bus=DBus
+        )
 
-    # Resolve an object path into a task.
-    task = container.from_object_path(path)
+        # Publish a task.
+        path = container.to_object_path(MyTask())
+
+        # Resolve an object path into a task.
+        task = container.from_object_path(path)
 
     """
 

--- a/dasbus/server/interface.py
+++ b/dasbus/server/interface.py
@@ -48,9 +48,14 @@ class dbus_signal(object):
     """DBus signal.
 
     Can be used as:
+
+    .. code-block:: python
+
         Signal = dbus_signal()
 
     Or as a method decorator:
+
+    .. code-block:: python
 
         @dbus_signal
         def Signal(x: Int, y: Double):
@@ -77,9 +82,9 @@ class dbus_signal(object):
 
         The descriptor has been assigned to the specified name.
         Generate a name of a private attribute that will be set
-        to a signal in the __get__ method.
+        to a signal in the ``__get__`` method.
 
-        For example: __dbus_signal_my_name
+        For example: ``__dbus_signal_my_name``
 
         :param owner: the owning class
         :param name: the descriptor name
@@ -126,6 +131,8 @@ def dbus_interface(interface_name, namespace=()):
 
     A new DBus interface can be defined as:
 
+    .. code-block:: python
+
         @dbus_interface
         class Interface():
             ...
@@ -135,6 +142,8 @@ def dbus_interface(interface_name, namespace=()):
     specification of the class.
 
     The XML specification is accessible as:
+    .. code-block:: python
+
         Interface.__dbus_xml__
 
     :param interface_name: a DBus name of the interface
@@ -154,6 +163,8 @@ def dbus_class(cls):
 
     A new DBus class can be defined as:
 
+    .. code-block:: python
+
         @dbus_class
         class Class(Interface):
             ...
@@ -164,7 +175,11 @@ def dbus_class(cls):
     The DBus XML specification will be generated from
     implemented interfaces (inherited) and it will be
     accessible as:
+
+    .. code-block:: python
+
         Class.__dbus_xml__
+
     """
     xml = DBusSpecificationGenerator.generate_specification(cls)
     setattr(cls, DBUS_XML_ATTRIBUTE, xml)
@@ -483,6 +498,9 @@ class DBusSpecificationGenerator(object):
         Ignore the difference between instance method and class method.
 
         For example:
+
+        .. code-block:: python
+
             class Foo(object):
                 def bar(cls, x):
                     pass
@@ -495,6 +513,7 @@ class DBusSpecificationGenerator(object):
 
             _is_method(Foo.bar) # True
             _is_method(Foo().bar) # True
+
         """
         return inspect.ismethod(member) or inspect.isfunction(member)
 

--- a/dasbus/server/property.py
+++ b/dasbus/server/property.py
@@ -152,9 +152,13 @@ class PropertiesInterface(ABC):
 
     Report the changed property:
 
+    .. code-block:: python
+
         self.report_changed_property('X')
 
     Emit all changes when the method is done:
+
+    .. code-block:: python
 
         @emits_properties_changed
         def SetX(x: Int):

--- a/dasbus/server/publishable.py
+++ b/dasbus/server/publishable.py
@@ -28,17 +28,19 @@ class Publishable(ABC):
 
     Example:
 
-    # Define a publishable class.
-    class MyObject(Publishable):
+    .. code-block:: python
 
-        def for_publication(self):
-            return MyDBusInterface(self)
+        # Define a publishable class.
+        class MyObject(Publishable):
 
-    # Create a publishable object.
-    my_object = MyObject()
+            def for_publication(self):
+                return MyDBusInterface(self)
 
-    # Publish the object on DBus.
-    DBus.publish_object("/org/project/x", my_object.for_publication())
+        # Create a publishable object.
+        my_object = MyObject()
+
+        # Publish the object on DBus.
+        DBus.publish_object("/org/project/x", my_object.for_publication())
 
    """
 

--- a/dasbus/server/template.py
+++ b/dasbus/server/template.py
@@ -43,21 +43,22 @@ class BasicInterfaceTemplate(ABC):
     and the getters and setters of properties should access the properties
     of the implementation.
 
-    Example:
+    .. code-block:: python
 
-    @dbus_interface("org.myproject.X")
-    class InterfaceX(BasicInterfaceTemplate):
-        def DoSomething(self) -> Str:
-            return self.implementation.do_something()
+        @dbus_interface("org.myproject.X")
+        class InterfaceX(BasicInterfaceTemplate):
+            def DoSomething(self) -> Str:
+                return self.implementation.do_something()
 
-    class X(object):
-        def do_something(self):
-            return "Done!"
+        class X(object):
+            def do_something(self):
+                return "Done!"
 
-    x = X()
-    i = InterfaceX(x)
+        x = X()
+        i = InterfaceX(x)
 
-    DBus.publish_object("/org/myproject/X", i)
+        DBus.publish_object("/org/myproject/X", i)
+
     """
 
     def __init__(self, implementation):
@@ -94,6 +95,8 @@ class InterfaceTemplate(BasicInterfaceTemplate, PropertiesInterface):
     org.freedesktop.DBus.Properties.
 
     Usage:
+
+    .. code-block:: python
 
         def connect_signals(self):
             super().connect_signals()

--- a/dasbus/typing.py
+++ b/dasbus/typing.py
@@ -103,6 +103,9 @@ def get_variant(type_hint, value):
     a type hint.
 
     Example:
+
+    .. code-block:: python
+
          v1 = get_variant(Bool, True)
          v2 = get_variant(List[Int], [1,2,3])
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,7 +14,7 @@ help:
 
 # Generate the API documentation.
 api:
-	sphinx-apidoc-3 -d 10 -o api ../dasbus
+	sphinx-apidoc-3 --separate -o api ../dasbus
 
 .PHONY: help api Makefile
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build-3
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/api/dasbus.client.handler.rst
+++ b/docs/api/dasbus.client.handler.rst
@@ -1,0 +1,7 @@
+dasbus.client.handler module
+============================
+
+.. automodule:: dasbus.client.handler
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.client.observer.rst
+++ b/docs/api/dasbus.client.observer.rst
@@ -1,0 +1,7 @@
+dasbus.client.observer module
+=============================
+
+.. automodule:: dasbus.client.observer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.client.property.rst
+++ b/docs/api/dasbus.client.property.rst
@@ -1,0 +1,7 @@
+dasbus.client.property module
+=============================
+
+.. automodule:: dasbus.client.property
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.client.proxy.rst
+++ b/docs/api/dasbus.client.proxy.rst
@@ -1,0 +1,7 @@
+dasbus.client.proxy module
+==========================
+
+.. automodule:: dasbus.client.proxy
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.client.rst
+++ b/docs/api/dasbus.client.rst
@@ -1,46 +1,9 @@
 dasbus.client package
 =====================
 
-Submodules
-----------
+.. toctree::
 
-dasbus.client.handler module
-----------------------------
-
-.. automodule:: dasbus.client.handler
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.client.observer module
------------------------------
-
-.. automodule:: dasbus.client.observer
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.client.property module
------------------------------
-
-.. automodule:: dasbus.client.property
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.client.proxy module
---------------------------
-
-.. automodule:: dasbus.client.proxy
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-Module contents
----------------
-
-.. automodule:: dasbus.client
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   dasbus.client.handler
+   dasbus.client.observer
+   dasbus.client.property
+   dasbus.client.proxy

--- a/docs/api/dasbus.connection.rst
+++ b/docs/api/dasbus.connection.rst
@@ -1,0 +1,7 @@
+dasbus.connection module
+========================
+
+.. automodule:: dasbus.connection
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.constants.rst
+++ b/docs/api/dasbus.constants.rst
@@ -1,0 +1,7 @@
+dasbus.constants module
+=======================
+
+.. automodule:: dasbus.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.error.rst
+++ b/docs/api/dasbus.error.rst
@@ -1,0 +1,7 @@
+dasbus.error module
+===================
+
+.. automodule:: dasbus.error
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.identifier.rst
+++ b/docs/api/dasbus.identifier.rst
@@ -1,0 +1,7 @@
+dasbus.identifier module
+========================
+
+.. automodule:: dasbus.identifier
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.loop.rst
+++ b/docs/api/dasbus.loop.rst
@@ -1,0 +1,7 @@
+dasbus.loop module
+==================
+
+.. automodule:: dasbus.loop
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.namespace.rst
+++ b/docs/api/dasbus.namespace.rst
@@ -1,0 +1,7 @@
+dasbus.namespace module
+=======================
+
+.. automodule:: dasbus.namespace
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.rst
+++ b/docs/api/dasbus.rst
@@ -1,110 +1,22 @@
-dasbus package
-==============
+Public API
+==========
 
-Subpackages
------------
+Let's look at the public API of the dasbus package.
 
 .. toctree::
+   :maxdepth: 1
+   :caption: Contents:
 
    dasbus.client
    dasbus.server
-
-Submodules
-----------
-
-dasbus.connection module
-------------------------
-
-.. automodule:: dasbus.connection
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.constants module
------------------------
-
-.. automodule:: dasbus.constants
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.error module
--------------------
-
-.. automodule:: dasbus.error
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.identifier module
-------------------------
-
-.. automodule:: dasbus.identifier
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.loop module
-------------------
-
-.. automodule:: dasbus.loop
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.namespace module
------------------------
-
-.. automodule:: dasbus.namespace
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.signal module
---------------------
-
-.. automodule:: dasbus.signal
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.specification module
----------------------------
-
-.. automodule:: dasbus.specification
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.structure module
------------------------
-
-.. automodule:: dasbus.structure
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.typing module
---------------------
-
-.. automodule:: dasbus.typing
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.xml module
------------------
-
-.. automodule:: dasbus.xml
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-Module contents
----------------
-
-.. automodule:: dasbus
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   dasbus.connection
+   dasbus.constants
+   dasbus.error
+   dasbus.identifier
+   dasbus.loop
+   dasbus.namespace
+   dasbus.signal
+   dasbus.specification
+   dasbus.structure
+   dasbus.typing
+   dasbus.xml

--- a/docs/api/dasbus.server.container.rst
+++ b/docs/api/dasbus.server.container.rst
@@ -1,0 +1,7 @@
+dasbus.server.container module
+==============================
+
+.. automodule:: dasbus.server.container
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.server.handler.rst
+++ b/docs/api/dasbus.server.handler.rst
@@ -1,0 +1,7 @@
+dasbus.server.handler module
+============================
+
+.. automodule:: dasbus.server.handler
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.server.interface.rst
+++ b/docs/api/dasbus.server.interface.rst
@@ -1,0 +1,7 @@
+dasbus.server.interface module
+==============================
+
+.. automodule:: dasbus.server.interface
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.server.property.rst
+++ b/docs/api/dasbus.server.property.rst
@@ -1,0 +1,7 @@
+dasbus.server.property module
+=============================
+
+.. automodule:: dasbus.server.property
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.server.publishable.rst
+++ b/docs/api/dasbus.server.publishable.rst
@@ -1,0 +1,7 @@
+dasbus.server.publishable module
+================================
+
+.. automodule:: dasbus.server.publishable
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.server.rst
+++ b/docs/api/dasbus.server.rst
@@ -1,62 +1,11 @@
 dasbus.server package
 =====================
 
-Submodules
-----------
+.. toctree::
 
-dasbus.server.container module
-------------------------------
-
-.. automodule:: dasbus.server.container
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.server.handler module
-----------------------------
-
-.. automodule:: dasbus.server.handler
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.server.interface module
-------------------------------
-
-.. automodule:: dasbus.server.interface
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.server.property module
------------------------------
-
-.. automodule:: dasbus.server.property
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.server.publishable module
---------------------------------
-
-.. automodule:: dasbus.server.publishable
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-dasbus.server.template module
------------------------------
-
-.. automodule:: dasbus.server.template
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-Module contents
----------------
-
-.. automodule:: dasbus.server
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   dasbus.server.container
+   dasbus.server.handler
+   dasbus.server.interface
+   dasbus.server.property
+   dasbus.server.publishable
+   dasbus.server.template

--- a/docs/api/dasbus.server.template.rst
+++ b/docs/api/dasbus.server.template.rst
@@ -1,0 +1,7 @@
+dasbus.server.template module
+=============================
+
+.. automodule:: dasbus.server.template
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.signal.rst
+++ b/docs/api/dasbus.signal.rst
@@ -1,0 +1,7 @@
+dasbus.signal module
+====================
+
+.. automodule:: dasbus.signal
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.specification.rst
+++ b/docs/api/dasbus.specification.rst
@@ -1,0 +1,7 @@
+dasbus.specification module
+===========================
+
+.. automodule:: dasbus.specification
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.structure.rst
+++ b/docs/api/dasbus.structure.rst
@@ -1,0 +1,7 @@
+dasbus.structure module
+=======================
+
+.. automodule:: dasbus.structure
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.typing.rst
+++ b/docs/api/dasbus.typing.rst
@@ -1,0 +1,7 @@
+dasbus.typing module
+====================
+
+.. automodule:: dasbus.typing
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/dasbus.xml.rst
+++ b/docs/api/dasbus.xml.rst
@@ -1,0 +1,7 @@
+dasbus.xml module
+=================
+
+.. automodule:: dasbus.xml
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,7 +1,0 @@
-dasbus
-======
-
-.. toctree::
-   :maxdepth: 10
-
-   dasbus

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,12 +51,6 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # A boolean that decides whether module names are prepended to all object names.
 add_module_names = False
 
-# A list of prefixes that are ignored for sorting the Python module index.
-modindex_common_prefix = ['dasbus.']
-
-# This value controls how to represents typehints.
-autodoc_typehints = 'none'
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,4 +67,4 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,10 @@
+# Conda environment file
+name: dasbus-docs-environment
+
+channels:
+  - defaults
+  - conda-forge
+
+dependencies:
+  - python=3
+  - pygobject

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,0 +1,215 @@
+Examples
+========
+
+Look at the `complete examples <https://github.com/rhinstaller/dasbus/tree/master/examples>`_ or
+`DBus services <https://github.com/rhinstaller/anaconda/tree/master/pyanaconda/modules>`_ of
+the Anaconda Installer for more inspiration.
+
+Basic usage
+-----------
+
+Show the current hostname.
+
+.. code-block:: python
+
+    from dasbus.connection import SystemMessageBus
+    bus = SystemMessageBus()
+
+    proxy = bus.get_proxy(
+        "org.freedesktop.hostname1",
+        "/org/freedesktop/hostname1"
+    )
+
+    print(proxy.Hostname)
+
+Send a notification to the notification server.
+
+.. code-block:: python
+
+    from dasbus.connection import SessionMessageBus
+    bus = SessionMessageBus()
+
+    proxy = bus.get_proxy(
+        "org.freedesktop.Notifications",
+        "/org/freedesktop/Notifications"
+    )
+
+    id = proxy.Notify(
+        "", 0, "face-smile", "Hello World!",
+        "This notification can be ignored.",
+        [], {}, 0
+    )
+
+    print("The notification {} was send.".format(id))
+
+Handle a closed notification.
+
+.. code-block:: python
+
+    from dasbus.loop import EventLoop
+    loop = EventLoop()
+
+    from dasbus.connection import SessionMessageBus
+    bus = SessionMessageBus()
+
+    proxy = bus.get_proxy(
+        "org.freedesktop.Notifications",
+        "/org/freedesktop/Notifications"
+    )
+
+    def callback(id, reason):
+        print("The notification {} was closed.".format(id))
+
+    proxy.NotificationClosed.connect(callback)
+    loop.run()
+
+Run the service org.example.HelloWorld.
+
+.. code-block:: python
+
+    from dasbus.loop import EventLoop
+    loop = EventLoop()
+
+    from dasbus.connection import SessionMessageBus
+    bus = SessionMessageBus()
+
+    class HelloWorld(object):
+        __dbus_xml__ = """
+        <node>
+            <interface name="org.example.HelloWorld">
+                <method name="Hello">
+                    <arg direction="in" name="name" type="s" />
+                    <arg direction="out" name="return" type="s" />
+                </method>
+            </interface>
+        </node>
+        """
+
+        def Hello(self, name):
+            return "Hello {}!".format(name)
+
+    bus.publish_object("/org/example/HelloWorld", HelloWorld())
+    bus.register_service("org.example.HelloWorld")
+    loop.run()
+
+
+Features
+--------
+
+Use constants to define DBus services and objects.
+
+.. code-block:: python
+
+    from dasbus.connection import SystemMessageBus
+    from dasbus.identifier import DBusServiceIdentifier
+
+    NETWORK_MANAGER = DBusServiceIdentifier(
+        namespace=("org", "freedesktop", "NetworkManager"),
+        message_bus=SystemMessageBus()
+    )
+
+    proxy = NETWORK_MANAGER.get_proxy()
+    print(proxy.NetworkingEnabled)
+
+Use exceptions to propagate and handle DBus errors.
+
+.. code-block:: python
+
+    from dasbus.error import dbus_error, DBusError
+
+    @dbus_error("org.freedesktop.DBus.Error.InvalidArgs")
+    class InvalidArgs(DBusError):
+        pass
+
+Call DBus methods asynchronously.
+
+.. code-block:: python
+
+    from dasbus.loop import EventLoop
+    loop = EventLoop()
+
+    def callback(call):
+        print(call())
+
+    proxy = NETWORK_MANAGER.get_proxy()
+    proxy.GetDevices(callback=callback)
+    loop.run()
+
+Generate XML specifications from Python classes.
+
+.. code-block:: python
+
+    from dasbus.server.interface import dbus_interface
+    from dasbus.typing import Str
+
+    @dbus_interface("org.example.HelloWorld")
+    class HelloWorld(object):
+
+        def Hello(self, name: Str) -> Str:
+            return "Hello {}!".format(name)
+
+    print(HelloWorld.__dbus_xml__)
+
+Represent DBus structures by Python objects.
+
+.. code-block:: python
+
+    from dasbus.structure import DBusData
+    from dasbus.typing import Str, get_variant
+
+    class UserData(DBusData):
+        def __init__(self):
+            self._name = ""
+
+        @property
+        def name(self) -> Str:
+            return self._name
+
+        @name.setter
+        def name(self, name):
+            self._name = name
+
+    data = UserData()
+    data.name = "Alice"
+
+    print(UserData.to_structure(data))
+    print(UserData.from_structure({
+        "name": get_variant(Str, "Bob")
+    }))
+
+Create Python objects that can be published on DBus.
+
+.. code-block:: python
+
+    from dasbus.server.interface import dbus_interface
+    from dasbus.server.template import InterfaceTemplate
+    from dasbus.server.publishable import Publishable
+    from dasbus.typing import Str
+
+    @dbus_interface("org.example.Chat")
+    class ChatInterface(InterfaceTemplate):
+
+        def Send(self, message: Str):
+            return self.implementation.send()
+
+    class Chat(Publishable):
+
+        def for_publication(self):
+            return ChatInterface(self)
+
+        def send(self, message):
+            print(message)
+
+Use DBus containers to publish dynamically created Python objects.
+
+.. code-block:: python
+
+    from dasbus.connection import SessionMessageBus
+    from dasbus.server.container import DBusContainer
+
+    container = DBusContainer(
+        namespace=("org", "example", "Chat"),
+        message_bus=SessionMessageBus()
+    )
+
+    print(container.to_object_path(Chat()))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,16 +1,49 @@
-.. dasbus documentation master file, created by
-   sphinx-quickstart on Wed Jan 22 21:51:51 2020.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Welcome to dasbus's documentation!
 ==================================
 
+Dasbus is a DBus library written in Python 3, based on GLib and inspired by pydbus.
+The code used to be part of the `Anaconda Installer <https://github.com/rhinstaller/anaconda>`_
+project. It was based on the `pydbus <https://github.com/LEW21/pydbus>`_ library, but we replaced
+it with our own solution because of its inactivity. The dasbus library is a result of this effort.
+
+Requirements
+____________
+
+* Python 3.6+
+* PyGObject 3
+
+You can install `PyGObject <https://pygobject.readthedocs.io>`_ provided by your system or use
+PyPI. The system package is usually called ``python3-gi``, ``python3-gobject`` or ``pygobject3``.
+See the `instructions <https://pygobject.readthedocs.io/en/latest/getting_started.html>`_ for
+your platform (only for PyGObject, you don't need cairo or GTK).
+
+The library is known to work with Python 3.8, PyGObject 3.34 and GLib 2.63, but these are not the
+required minimal versions.
+
+Installation
+------------
+
+Install the package from `PyPI <https://pypi.org/project/dasbus/>`_. Follow the instructions above
+to install the required dependencies.
+
+::
+
+    pip3 install dasbus
+
+
+Or install the RPM package on Fedora.
+
+::
+
+    sudo dnf install python3-dasbus
+
+
 .. toctree::
-   :maxdepth: 5
+   :maxdepth: 1
    :caption: Contents:
 
-   api/dasbus
+   Examples <examples>
+   Public API <api/dasbus>
 
 Indices and tables
 ==================


### PR DESCRIPTION
Fix all warnings from the generated documentation. Mark the code blocks,
disable static files and remove the unused file modules.rst.

It is not possible to build the documentation without PyGObject. Provide new
configuration files for Read the Docs and Conda and customize the environment.

Extend the documentation. Add a file per submodule, extend index.rst and add
a new file examples.rst.

Test the documentation build. Add a new target docs to the Makefile, turn warnings
from the docs build into errors and set up Travis CI to be able to run 'make docs'
in the container.