### PR TITLE
Improve the support for interface proxies

### DIFF
--- a/dasbus/identifier.py
+++ b/dasbus/identifier.py
@@ -144,28 +144,47 @@ class DBusServiceIdentifier(DBusObjectIdentifier):
         """Return the string representation."""
         return self.service_name
 
-    def _choose_object_path(self, object_path):
+    def _choose_object_path(self, object_id):
         """Choose an object path."""
-        if object_path is None:
+        if object_id is None:
             return self.object_path
 
-        if isinstance(object_path, DBusObjectIdentifier):
-            return object_path.object_path
+        if isinstance(object_id, DBusObjectIdentifier):
+            return object_id.object_path
 
-        return object_path
+        return object_id
 
-    def _choose_interface_names(self, object_path, interface_names):
-        """Choose interface names."""
-        if object_path is None and interface_names is None:
-            return [self.interface_name]
+    def _choose_interface_name(self, interface_id):
+        """Choose an interface name."""
+        if interface_id is None:
+            return None
 
-        return interface_names
+        if isinstance(interface_id, DBusInterfaceIdentifier):
+            return interface_id.interface_name
 
-    def get_proxy(self, object_path=None):
+        return interface_id
+
+    def get_proxy(self, object_path=None, interface_name=None,
+                  **bus_arguments):
         """Returns a proxy of the DBus object.
 
-        :param object_path: a DBus path an object or None
+        If no object path is specified, we will use the object path
+        of this DBus service.
+
+        If no interface name is specified, we will use none and create
+        a proxy from all interfaces of the DBus object.
+
+        :param object_path: an object identifier or a DBus path or None
+        :param interface_name: an interface identifier or a DBus name or None
+        :param bus_arguments: additional arguments for the message bus
         :return: a proxy object
         """
         object_path = self._choose_object_path(object_path)
-        return self._message_bus.get_proxy(self.service_name, object_path)
+        interface_name = self._choose_interface_name(interface_name)
+
+        return self._message_bus.get_proxy(
+            self.service_name,
+            object_path,
+            interface_name,
+            **bus_arguments
+        )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -105,6 +105,24 @@ class DBusConnectionTestCase(unittest.TestCase):
 
         self.assertEqual(proxy, self.proxy_factory.return_value)
 
+    def test_interface_proxy(self):
+        """Test the interface proxy."""
+        proxy = self.message_bus.get_proxy(
+            "service.name",
+            "/object/path",
+            "interface.name"
+        )
+
+        self.proxy_factory.assert_called_once_with(
+            self.message_bus,
+            "service.name",
+            "/object/path",
+            interface_name="interface.name",
+            error_mapper=self.error_mapper
+        )
+
+        self.assertEqual(proxy, self.proxy_factory.return_value)
+
     def test_bus_proxy(self):
         """Test the bus proxy."""
         proxy = self.message_bus.proxy

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -163,9 +163,94 @@ class DBusServiceIdentifierTestCase(unittest.TestCase):
         )
 
         service.get_proxy()
-        bus.get_proxy.assert_called_with("a.b.c", "/a/b/c")
+        bus.get_proxy.assert_called_with(
+            "a.b.c",
+            "/a/b/c",
+            None
+        )
         bus.reset_mock()
 
-        service.get_proxy(obj.object_path)
-        bus.get_proxy.assert_called_with("a.b.c", "/a/b/c/object")
+        service.get_proxy("/a/b/c/object")
+        bus.get_proxy.assert_called_with(
+            "a.b.c",
+            "/a/b/c/object",
+            None
+        )
+        bus.reset_mock()
+
+        service.get_proxy(obj)
+        bus.get_proxy.assert_called_with(
+            "a.b.c",
+            "/a/b/c/object",
+            None
+        )
+        bus.reset_mock()
+
+    def test_get_proxy_for_interface(self):
+        """Test getting a proxy for an interface."""
+        bus = Mock()
+        namespace = ("a", "b", "c")
+
+        service = DBusServiceIdentifier(
+            namespace=namespace,
+            message_bus=bus
+        )
+
+        interface = DBusInterfaceIdentifier(
+            basename="interface",
+            namespace=namespace
+        )
+
+        service.get_proxy(
+            interface_name="a.b.c.interface"
+        )
+        bus.get_proxy.assert_called_with(
+            "a.b.c",
+            "/a/b/c",
+            "a.b.c.interface"
+        )
+        bus.reset_mock()
+
+        service.get_proxy(
+            interface_name=interface
+        )
+        bus.get_proxy.assert_called_with(
+            "a.b.c",
+            "/a/b/c",
+            "a.b.c.interface"
+        )
+        bus.reset_mock()
+
+    def test_get_proxy_with_bus_arguments(self):
+        """Test getting a proxy with an additional arguments."""
+        bus = Mock()
+        error_mapper = Mock()
+        namespace = ("a", "b", "c")
+
+        service = DBusServiceIdentifier(
+            namespace=namespace,
+            message_bus=bus
+        )
+
+        service.get_proxy(
+            error_mapper=error_mapper
+        )
+        bus.get_proxy.assert_called_with(
+            "a.b.c",
+            "/a/b/c",
+            None,
+            error_mapper=error_mapper
+        )
+        bus.reset_mock()
+
+        service.get_proxy(
+            interface_name=service,
+            error_mapper=error_mapper
+        )
+        bus.get_proxy.assert_called_with(
+            "a.b.c",
+            "/a/b/c",
+            "a.b.c",
+            error_mapper=error_mapper
+        )
         bus.reset_mock()


### PR DESCRIPTION
Call message_bus.get_proxy(service_name, object_path, interface_name) to get
a proxy for a specific DBus interface. It is no longer necessary to explicitly
change the proxy factory.

Call service.get_proxy(interface_name=interface) to get a proxy for a specific
DBus interface. Any other keyword arguments will be propagated to the message
bus.

Add tests for the InterfaceProxy class.