### PR TITLE
Handle all errors of the DBus call

### DIFF
--- a/dasbus/client/handler.py
+++ b/dasbus/client/handler.py
@@ -472,10 +472,9 @@ class ClientObjectHandler(AbstractClientObjectHandler):
         """
         try:
             result = call(*args, **kwargs)
+            return self._handle_method_result(result)
         except Exception as error:  # pylint: disable=broad-except
             return self._handle_method_error(error)
-        else:
-            return self._handle_method_result(result)
 
     def _handle_method_error(self, error):
         """Handle an error of a DBus call.

--- a/dasbus/server/handler.py
+++ b/dasbus/server/handler.py
@@ -420,18 +420,17 @@ class ServerObjectHandler(AbstractServerObjectHandler):
                 method_name,
                 *unwrap_variant(parameters)
             )
+            self._handle_method_result(
+                invocation,
+                member,
+                result
+            )
         except Exception as error:  # pylint: disable=broad-except
             self._handle_method_error(
                 invocation,
                 interface_name,
                 method_name,
                 error
-            )
-        else:
-            self._handle_method_result(
-                invocation,
-                member,
-                result
             )
 
     def _handle_method_error(self, invocation, interface_name, method_name,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -256,6 +256,22 @@ class DBusClientTestCase(unittest.TestCase):
             str(cm.exception)
         )
 
+    def test_invalid_method_result(self):
+        """Test a method proxy with an invalid result."""
+        self._create_proxy("""
+        <node>
+            <interface name="Interface">
+                <method name="Method">
+                    <arg direction="out" name="return" type="t"/>
+                </method>
+            </interface>
+        </node>
+        """)
+
+        self._set_reply(get_variant("i", -1))
+        with self.assertRaises(TypeError):
+            self.proxy.Method()
+
     def _set_reply(self, reply_value):
         """Set the reply of the DBus call."""
         self.connection.call_sync.reset_mock()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -82,8 +82,8 @@ class DBusServerTestCase(unittest.TestCase):
 
     def _call_method_with_error(self, interface, method,
                                 parameters=NO_PARAMETERS,
-                                error_name="",
-                                error_message=""):
+                                error_name=None,
+                                error_message=None):
         invocation = Mock()
 
         with self.assertLogs(level='WARN'):
@@ -94,11 +94,16 @@ class DBusServerTestCase(unittest.TestCase):
                 parameters
             )
 
-        invocation.return_dbus_error.assert_called_once_with(
-            error_name,
-            error_message
-        )
+        invocation.return_dbus_error.assert_called_once()
         invocation.return_value.assert_not_called()
+
+        (name, msg), kwargs = invocation.return_dbus_error.call_args
+
+        self.assertEqual(kwargs, {})
+        self.assertEqual(name, error_name, "Unexpected error name.")
+
+        if error_message is not None:
+            self.assertEqual(msg, error_message, "Unexpected error message.")
 
     def test_register(self):
         """Test the object registration."""
@@ -191,6 +196,25 @@ class DBusServerTestCase(unittest.TestCase):
             "Method1",
             error_name="MethodFailed",
             error_message="The method has failed."
+        )
+
+    def test_invalid_method_result(self):
+        """Test a method with an invalid result."""
+        self._publish_object("""
+        <node>
+            <interface name="Interface">
+                <method name="Method">
+                    <arg direction="out" name="return" type="t"/>
+                </method>
+            </interface>
+        </node>
+        """)
+
+        self.object.Method.return_value = -1
+        self._call_method_with_error(
+            "Interface",
+            "Method",
+            error_name="not.known.Error.OverflowError"
         )
 
     def test_property(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -94,7 +94,10 @@ class DBusServerTestCase(unittest.TestCase):
                 parameters
             )
 
-        invocation.return_dbus_error(error_name, error_message)
+        invocation.return_dbus_error.assert_called_once_with(
+            error_name,
+            error_message
+        )
         invocation.return_value.assert_not_called()
 
     def test_register(self):
@@ -171,8 +174,8 @@ class DBusServerTestCase(unittest.TestCase):
             "Interface",
             "MethodInvalid",
             error_name="not.known.Error.DBusSpecificationError",
-            error_message="Unknown member MethodInvalid of "
-                          "the interface Interface."
+            error_message="DBus specification has no member "
+                          "'Interface.MethodInvalid'."
         )
 
         self.error_mapper.add_rule(ErrorRule(
@@ -238,8 +241,9 @@ class DBusServerTestCase(unittest.TestCase):
                 "Property2",
                 get_variant("s", "World")
             )),
-            error_name="not.known.AttributeError",
-            error_message="Property2 of Interface is not writable."
+            error_name="not.known.Error.AttributeError",
+            error_message="The property Interface.Property2 "
+                          "is not writable."
         )
         self.assertEqual(self.object.Property2, "Hello")
 
@@ -250,8 +254,9 @@ class DBusServerTestCase(unittest.TestCase):
                 "Interface",
                 "Property3"
             )),
-            error_name="not.known.AttributeError",
-            error_message="Property3 of Interface is not readable."
+            error_name="not.known.Error.AttributeError",
+            error_message="The property Interface.Property3 "
+                          "is not readable."
         )
         self._call_method(
             "org.freedesktop.DBus.Properties", "Set",


### PR DESCRIPTION
Don't handle only errors caused by the method invocation, but handle
also errors caused by processing the result of the method.