### PR TITLE
Enable Packit build in ELN chroot

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,3 +13,4 @@ jobs:
   metadata:
     targets:
     - fedora-all
+    - fedora-eln


### PR DESCRIPTION
This will help us to discover problems for next RHEL.