### PR TITLE
Switch Packit tests to copr builds instead

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,7 +8,7 @@ actions:
     - 'bash -c "cp dist/*.tar.gz ."'
     - 'bash -c "ls *.tar.gz"'
 jobs:
-- job: tests
+- job: copr_build
   trigger: pull_request
   metadata:
     targets:


### PR DESCRIPTION
ELN chroot is not supported by Cruncher so the testing wouldn't work there.
Let's instead just run the build and avoid running even the smoke tests. I think when the Cruncher is still so unstable this will be the best option for dasbus project.