### PR TITLE
Migrate daily COPR builds to Packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,9 +8,20 @@ actions:
     - 'bash -c "cp dist/*.tar.gz ."'
     - 'bash -c "ls *.tar.gz"'
 jobs:
-- job: copr_build
-  trigger: pull_request
-  metadata:
-    targets:
-    - fedora-all
-    - fedora-eln
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      targets:
+      - fedora-all
+      - fedora-eln
+
+  - job: copr_build
+    trigger: commit
+    metadata:
+      targets:
+        - fedora-rawhide
+        - fedora-eln
+      branch: master
+      owner: "@rhinstaller"
+      project: Anaconda
+      preserve_project: True


### PR DESCRIPTION
Let's leave Packit to handle this.

-------------------------
Replacing https://github.com/rhinstaller/dasbus/pull/46. Which was created from a bad branch.

Also removing custom COPR repositories. Seems it's not really required for non-Anaconda projects for Packit COPR builds.

You can see test result [here](https://github.com/jkonecny12/dasbus/commit/020ee45cbebd40c4ebcce48d6ff1828102e4ff28).