### PR TITLE
Add daily builds for our Fedora-devel COPR repository

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,3 +25,13 @@ jobs:
       owner: "@rhinstaller"
       project: Anaconda
       preserve_project: True
+
+  - job: copr_build
+    trigger: commit
+    metadata:
+      targets:
+        - fedora-34
+      branch: master
+      owner: "@rhinstaller"
+      project: Anaconda-devel
+      preserve_project: True


### PR DESCRIPTION
The dasbus project using master for Fedora Rawhide but also for Fedora in development. Lets add that one now.