### PR TITLE
Use Fedora container registry instead of Dockerhub

### DIFF
--- a/.travis/Dockerfile.fedora-rawhide
+++ b/.travis/Dockerfile.fedora-rawhide
@@ -1,4 +1,4 @@
-FROM fedora:rawhide
+FROM registry.fedoraproject.org/fedora:rawhide
 ENV LANG C.utf8
 
 RUN dnf -y install \


### PR DESCRIPTION
First they are more up to date so we will avoid issue with bad GPG keys we have now.
Second there is no limit for downloads.