### PR TITLE
Switch to packit new fedora-latest alias

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,7 +30,7 @@ jobs:
     trigger: commit
     metadata:
       targets:
-        - fedora-34
+        - fedora-latest
       branch: master
       owner: "@rhinstaller"
       project: Anaconda-devel


### PR DESCRIPTION
This alias will always point to the latests Fedora which is not Rawhide. That will enable us to just not care for this project.