### PR TITLE
Change the type of 'h' glib objects from 'File' to 'UnixFD'

### DIFF
--- a/dasbus/typing.py
+++ b/dasbus/typing.py
@@ -22,7 +22,7 @@
 # https://dbus.freedesktop.org/doc/dbus-specification.html#type-system.
 #
 
-from typing import Tuple, Dict, List, NewType, IO
+from typing import Tuple, Dict, List, NewType
 
 import gi
 gi.require_version("GLib", "2.0")
@@ -40,7 +40,7 @@ __all__ = [
     "UInt32",
     "Int64",
     "UInt64",
-    "File",
+    "UnixFD",
     "ObjPath",
     "Variant",
     "VariantType",
@@ -74,9 +74,7 @@ Int32 = NewType('Int32', int)
 UInt32 = NewType('UInt32', int)
 Int64 = NewType('Int64', int)
 UInt64 = NewType('UInt64', int)
-
-# Type of a file handler.
-File = IO
+UnixFD = NewType('UnixFD', int)
 
 # Type of an object path.
 ObjPath = NewType('ObjPath', str)
@@ -285,7 +283,7 @@ class DBusType(object):
         Int64:      "x",
         UInt64:     "t",
         # Other basic types.
-        File:       "h",
+        UnixFD:     "h",
         ObjPath:    "o",
         Variant:    "v"
     }

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -18,7 +18,7 @@
 #
 import unittest
 
-from dasbus.typing import Int, Str, List, Double, File, Tuple, Bool, Dict
+from dasbus.typing import Int, Str, List, Double, UnixFD, Tuple, Bool, Dict
 from dasbus.server.interface import dbus_interface, dbus_class, dbus_signal, \
     get_xml, DBusSpecificationGenerator, DBusSpecificationError, \
     accepts_additional_arguments, returns_multiple_arguments
@@ -184,7 +184,7 @@ class InterfaceGeneratorTestCase(unittest.TestCase):
             def Method3(self) -> Int:
                 pass
 
-            def Method4(self, x: List[Double], y: File) -> Tuple[Int, Bool]:
+            def Method4(self, x: List[Double], y: UnixFD) -> Tuple[Int, Bool]:
                 return 0, True
 
         expected_xml = '''

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -24,7 +24,7 @@ from typing import Set
 from dasbus.typing import get_dbus_type, is_base_type, get_native, \
     get_variant, get_variant_type, Int, Int16, Int32, Int64, UInt16, UInt32, \
     UInt64, Bool, Byte, Str, Dict, List, Tuple, Variant, Double, ObjPath, \
-    File, unwrap_variant, get_type_name, is_tuple_of_one, get_type_arguments
+    UnixFD, unwrap_variant, get_type_name, is_tuple_of_one, get_type_arguments
 
 import gi
 gi.require_version("GLib", "2.0")
@@ -153,7 +153,7 @@ class DBusTypingTests(unittest.TestCase):
         self._compare(Double, "d")
         self._compare(Str, "s")
         self._compare(ObjPath, "o")
-        self._compare(File, "h")
+        self._compare(UnixFD, "h")
         self._compare(Variant, "v")
 
     def test_int(self):
@@ -170,11 +170,11 @@ class DBusTypingTests(unittest.TestCase):
         """Test container types."""
         self._compare(Tuple[Bool], "(b)")
         self._compare(Tuple[Int, Str], "(is)")
-        self._compare(Tuple[File, Variant, Double], "(hvd)")
+        self._compare(Tuple[UnixFD, Variant, Double], "(hvd)")
 
         self._compare(List[Int], "ai")
         self._compare(List[Bool], "ab")
-        self._compare(List[File], "ah")
+        self._compare(List[UnixFD], "ah")
         self._compare(List[ObjPath], "ao")
 
         self._compare(Dict[Str, Int], "a{si}")
@@ -193,7 +193,7 @@ class DBusTypingTests(unittest.TestCase):
 
         self._compare(List[List[List[Int]]], "aaai")
         self._compare(List[Tuple[Dict[Str, Int]]], "a(a{si})")
-        self._compare(List[Dict[Str, Tuple[File, Variant]]], "aa{s(hv)}")
+        self._compare(List[Dict[Str, Tuple[UnixFD, Variant]]], "aa{s(hv)}")
 
         self._compare(Dict[Str, List[Bool]], "a{sab}")
         self._compare(Dict[Str, Tuple[Int, Int, Double]], "a{s(iid)}")


### PR DESCRIPTION
This is how python-gio expects files to be sent across dbus.

This is one of several PRs that are descended from #67. I'll create more once this is merged.