### PR TITLE
Provide a language argument for the code blocks

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -4,12 +4,12 @@ Development and testing
 Install `podman <https://podman.io/>`_ and use the following command to run all tests
 in a container. It doesn't require any additional dependencies:
 
-.. code-block::
+.. code-block:: shell
 
     make container-ci
 
 Use the command below to run only the unit tests:
 
-.. code-block::
+.. code-block:: shell
 
     make container-ci CI_CMD="make test"


### PR DESCRIPTION
If no language argument for the code blocks is given, I get those warnings when building the documentation during a package build on a Ubuntu 20.04 system:
````
/build/dasbus-1.6.8+git20211005-g92f1841-92f1841/docs/development.rst:7: WARNING: Error in "code-block" directive:
1 argument(s) required, 0 supplied.

.. code-block::

    make container-ci
/build/dasbus-1.6.8+git20211005-g92f1841-92f1841/docs/development.rst:13: WARNING: Error in "code-block" directive:
1 argument(s) required, 0 supplied.

.. code-block::
````