### PR TITLE
Being able to get signal from any sender

### DIFF
--- a/dasbus/client/handler.py
+++ b/dasbus/client/handler.py
@@ -106,7 +106,7 @@ class GLibClient(object):
         :return: a callback to unsubscribe
         """
         subscription_id = connection.signal_subscribe(
-            service_name,
+            None,
             interface_name,
             signal_name,
             object_path,


### PR DESCRIPTION
For now we able to subscribe to signal only with  `service_name` sender, which is wrong in my opinion for signals