### PR TITLE
Fix pylint issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -68,7 +68,6 @@ disable=invalid-name,
         wrong-import-position,
         assigning-non-slot,
         no-member,
-        no-self-use,
         useless-object-inheritance,
         duplicate-code,
         too-many-instance-attributes,
@@ -146,13 +145,6 @@ max-line-length=79
 
 # Maximum number of lines in a module.
 max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/.travis/Dockerfile.centos-stream-8
+++ b/.travis/Dockerfile.centos-stream-8
@@ -1,5 +1,5 @@
 FROM quay.io/centos/centos:stream8
-ENV LANG C.utf8
+ENV LANG=C.utf8
 
 RUN yum -y update; \
     yum -y install \

--- a/.travis/Dockerfile.centos-stream-8
+++ b/.travis/Dockerfile.centos-stream-8
@@ -1,6 +1,9 @@
 FROM quay.io/centos/centos:stream8
 ENV LANG=C.utf8
 
+# The pylintrc file is no longer compatible with older pylint.
+ENV CHECK_ARGS="--disable=no-self-use,bad-option-value"
+
 RUN yum -y update; \
     yum -y install \
     make \

--- a/.travis/Dockerfile.centos-stream-9
+++ b/.travis/Dockerfile.centos-stream-9
@@ -1,5 +1,5 @@
 FROM quay.io/centos/centos:stream9
-ENV LANG C.utf8
+ENV LANG=C.utf8
 
 RUN yum -y update; \
     yum -y install \

--- a/.travis/Dockerfile.debian-latest
+++ b/.travis/Dockerfile.debian-latest
@@ -1,5 +1,5 @@
 FROM debian:latest
-ENV LANG C.utf8
+ENV LANG=C.utf8
 
 RUN apt-get update && \
     apt-get install -y \

--- a/.travis/Dockerfile.fedora-rawhide
+++ b/.travis/Dockerfile.fedora-rawhide
@@ -1,5 +1,5 @@
 FROM registry.fedoraproject.org/fedora:rawhide
-ENV LANG C.utf8
+ENV LANG=C.utf8
 
 RUN dnf -y update; \
     dnf -y install \

--- a/.travis/Dockerfile.ubuntu-devel
+++ b/.travis/Dockerfile.ubuntu-devel
@@ -1,5 +1,5 @@
 FROM ubuntu:devel
-ENV LANG C.utf8
+ENV LANG=C.utf8
 
 # Disable interaction with tzdata.
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ CI_CMD?=make ci
 # Arguments used for setup.py call for creating archive
 BUILD_ARGS ?= sdist bdist_wheel
 
+# Arguments used by pylint for checking the code.
+CHECK_ARGS ?=
+
 .PHONY: clean
 clean:
 	git clean -fdx
@@ -47,7 +50,7 @@ ci:
 .PHONY: check
 check:
 	@echo "*** Running pylint ***"
-	$(PYTHON) -m pylint dasbus/ tests/
+	$(PYTHON) -m pylint $(CHECK_ARGS) dasbus/ tests/
 
 .PHONY: test
 test:

--- a/dasbus/client/property.py
+++ b/dasbus/client/property.py
@@ -40,7 +40,7 @@ class PropertyProxy(object):
 
     def get(self):
         """Get the value of the DBus property."""
-        return self.__get__(None, None)
+        return self.__get__(None, None)  # pylint: disable=unnecessary-dunder-call
 
     def __get__(self, instance, owner):
         if instance is None and owner:
@@ -55,7 +55,7 @@ class PropertyProxy(object):
 
     def set(self, value):
         """Set the value of the DBus property."""
-        return self.__set__(None, value)
+        return self.__set__(None, value)  # pylint: disable=unnecessary-dunder-call
 
     def __set__(self, instance, value):
         if not self._setter:

--- a/dasbus/typing.py
+++ b/dasbus/typing.py
@@ -415,7 +415,7 @@ def array_replace_handles_with_fdlist_indices(e, typestring, fdlist):
             if typestring[1] == 'v':
                 p = variant_replace_handles_with_fdlist_indices(
                     f, fdlist)
-                newlist[j], fdlist = p
+                newlist[j], fdlist = p  # pylint: disable=unnecessary-list-index-lookup
             else:
                 nv = get_variant(typestring[1:], f)
                 p = variant_replace_handles_with_fdlist_indices(


### PR DESCRIPTION
* The `no-self-use` pylint check is now optional.
* The `no-space-check` pylint option is deprecated.
* Ignore new false positives.
* Fix the ENV instruction in Dockerfiles.
* Fix pylint tests in CentOS Stream 8.