### PR TITLE
UnixFD: Revert a change in GLibClient._async_call_finish

### DIFF
--- a/dasbus/client/handler.py
+++ b/dasbus/client/handler.py
@@ -96,7 +96,7 @@ class GLibClient(object):
 
         # Call user's callback.
         callback(
-            lambda: source_object.call_with_unix_fd_list_finish(result_object),
+            lambda: source_object.call_finish(result_object),
             *callback_args
         )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -392,13 +392,13 @@ class DBusClientTestCase(unittest.TestCase):
             if isinstance(result_object, Exception):
                 raise result_object
 
-            return (result_object,)
+            return result_object
 
         def _callback(finish, *args):
             callback(finish(), *args)
 
         GLibClient._async_call_finish(
-            source_object=Mock(call_with_unix_fd_list_finish=_call_finish),
+            source_object=Mock(call_finish=_call_finish),
             result_object=result,
             user_data=(
                 self.handler._method_callback,


### PR DESCRIPTION
The change was introduced in 8038b23 and was supposed to be removed in 0332d74.