### PR TITLE
Simplify the code for replacing values of the UnixFD type

### DIFF
--- a/dasbus/typing.py
+++ b/dasbus/typing.py
@@ -446,181 +446,83 @@ class VariantUnwrapper(VariantUnpacking):
         return variant.get_variant()
 
 
-def dictionary_replace_handles_with_fdlist_indices(v, fdlist):
-    typestring = v.get_type_string()
-    newdict = {}
-    keytype=typestring[2]
-    valuetype=typestring[3:-1]
-    e = unwrap_variant(v)
-    for key, value in e.items():
-        #according to the spec, the key is a basic type.
-        #we have to handle the crazy case where somebody
-        #uses a file descriptor as a dictionary key
-        if keytype == 'h':
-            l = len(fdlist)
-            fdlist.append(key)
-            key = l
-        if valuetype == 'h':
-            l = len(fdlist)
-            fdlist.append(value)
-            value = l
-        elif valuetype == 'v':
-            value, fdlist = variant_replace_handles_with_fdlist_indices(
-                value, fdlist)
-        elif not DBusType._is_basic_type(valuetype):
-            value, fdlist = variant_replace_handles_with_fdlist_indices(
-                get_variant(valuetype, value), fdlist)
-            value = unwrap_variant(value)
-        newdict[key] = value
-    return get_variant(typestring, newdict), fdlist
+class UnixFDSwap(VariantUnpacking):
+    """Class for swapping values of the UnixFD type."""
 
-def array_replace_handles_with_fdlist_indices(e, typestring, fdlist):
-    if typestring[1] == '{':
-        nv, fdlist = variant_replace_handles_with_fdlist_indices(
-            get_variant(typestring, e), fdlist)
-        return unwrap_variant(nv), fdlist
-    else:
-        newlist = e.copy()
-        for j, f in enumerate(newlist):
-            if typestring[1] == 'v':
-                p = variant_replace_handles_with_fdlist_indices(
-                    f, fdlist)
-                newlist[j], fdlist = p  # pylint: disable=unnecessary-list-index-lookup
-            else:
-                nv = get_variant(typestring[1:], f)
-                p = variant_replace_handles_with_fdlist_indices(
-                    nv, fdlist)
-                nnv, fdlist = p
-                newlist[j] = unwrap_variant(nnv)
-        return newlist, fdlist
+    @classmethod
+    def apply(cls, variant, swap):
+        """Swap unix file descriptors with indices.
+
+        The provided function should swap a unix file
+        descriptor with an index into an array of unix
+        file descriptors or vice versa.
+
+        :param variant: a variant to modify
+        :param swap: a swapping function
+        :return: a modified variant
+        """
+        return cls._recreate_variant(variant, swap)
+
+    @classmethod
+    def _handle_variant(cls, variant, *extras):
+        """Handle a variant."""
+        return cls._recreate_variant(variant.get_variant(), *extras)
+
+    @classmethod
+    def _handle_value(cls, variant, *extras):
+        """Handle a basic value."""
+        type_string = variant.get_type_string()
+
+        # Handle the unix file descriptor.
+        if type_string == 'h':
+            # Get the swapping function.
+            swap, *_ = extras
+            # Swap the values.
+            return swap(variant.get_handle())
+
+        return variant.unpack()
+
+    @classmethod
+    def _recreate_variant(cls, variant, *extras):
+        """Create a variant with swapped values."""
+        type_string = variant.get_type_string()
+
+        # Do nothing if there is no unix file descriptor to handle.
+        if 'h' not in type_string and 'v' not in type_string:
+            return variant
+
+        # Get a new value of the variant.
+        value = cls._process_variant(variant, *extras)
+
+        # Create a new variant.
+        return get_variant(type_string, value)
 
 
 def variant_replace_handles_with_fdlist_indices(v, fdlist=None):
     """Given a variant, return a new variant
     with all 'h' handles replaced with FDlist indices,
-    adding extracted handles to the fdlist passed as an argument"""
-    if fdlist is None:
-        fdlist = []
+    adding extracted handles to the fdlist passed as an argument.
 
-    if v.get_type().is_basic():
-        if v.get_type_string() == 'h':
-            l = len(fdlist)
-            fd = unwrap_variant(v)
-            fdlist.append(fd)
-            return get_variant('h', l), fdlist
-        else:
-            return v, fdlist
+    FIXME: This is a temporary method. Call UnixFDSwap instead.
+    """
+    indices = fdlist or []
 
-    typestring = v.get_type_string()
+    def get_index(fd_handler):
+        indices.append(fd_handler)
+        return len(indices) - 1
 
-    if typestring.startswith('a'):
-        if typestring.startswith('a{'):
-            return dictionary_replace_handles_with_fdlist_indices(v, fdlist)
-        a, fdlist = array_replace_handles_with_fdlist_indices(
-            unwrap_variant(v), typestring, fdlist)
-        return get_variant(typestring, a), fdlist
+    return UnixFDSwap.apply(v, get_index), indices
 
-
-    typelist = v.split_signature(typestring)
-    unwrapped = list(unwrap_variant(v))
-    for i, e in enumerate(unwrapped):
-        if typelist[i] == 'h':
-            l = len(fdlist)
-            fdlist.append(e)
-            unwrapped[i] = l
-        elif typelist[i][0] == 'a':
-            unwrapped[i], fdlist = array_replace_handles_with_fdlist_indices(
-                e, typelist[i], fdlist)
-        elif typelist[i] == 'v':
-            unwrapped[i], fdlist = variant_replace_handles_with_fdlist_indices(
-                e, fdlist)
-        else:
-            nv = get_variant(typelist[i], e)
-            nnv, fdlist = variant_replace_handles_with_fdlist_indices(
-                nv, fdlist)
-            unwrapped[i] = unwrap_variant(nnv)
-    return get_variant(typestring, unwrapped), fdlist
-
-def dictionary_replace_fdlist_indices_with_handles(v, fdlist):
-    typestring = v.get_type_string()
-
-    newdict = {}
-    keytype=typestring[2]
-    valuetype=typestring[3:-1]
-    e = unwrap_variant(v)
-    for key, value in e.items():
-        #according to the spec, the key is a basic type.
-        #we have to handle the crazy case where somebody
-        #uses a file descriptor as a dictionary key
-        if keytype == 'h':
-            key = fdlist[key]
-        if valuetype == 'h':
-            value = fdlist[value]
-        elif valuetype == 'v':
-            value = variant_replace_fdlist_indices_with_handles(
-                value, fdlist)
-        elif not DBusType._is_basic_type(valuetype):
-            value = variant_replace_fdlist_indices_with_handles(
-                get_variant(valuetype, value), fdlist)
-            value = unwrap_variant(value)
-        newdict[key] = value
-
-    return get_variant(typestring, newdict)
-
-def array_replace_fdlist_indices_with_handles(e, typestring, fdlist):
-    if typestring[1] == '{':
-        nv = variant_replace_fdlist_indices_with_handles(
-            get_variant(typestring, e), fdlist)
-        return unwrap_variant(nv)
-    else:
-        newlist = e.copy()
-        for j, f in enumerate(newlist):
-            if typestring[1] == 'v':
-                p = variant_replace_fdlist_indices_with_handles(
-                    f, fdlist)
-                newlist[j] = p
-            else:
-                nv = get_variant(typestring[1:], f)
-                nnv = variant_replace_fdlist_indices_with_handles(
-                    nv, fdlist)
-                newlist[j] = unwrap_variant(nnv)
-        return newlist
 
 def variant_replace_fdlist_indices_with_handles(v, fdlist):
     """Given a varaint and an fdlist, find any 'h' handle instances
-    and replace them with file descriptors that they represent"""
+    and replace them with file descriptors that they represent.
 
-    if v.get_type().is_basic():
-        if v.get_type_string() == 'h':
-            idx = unwrap_variant(v)
-            return get_variant('h', fdlist[idx])
-        else:
-            return v
+    FIXME: This is a temporary method. Call UnixFDSwap instead.
+    """
+    indices = fdlist
 
-    typestring = v.get_type_string()
+    def get_handler(fd_index):
+        return indices[fd_index]
 
-    if typestring.startswith('a'):
-        if typestring.startswith('a{'):
-            return dictionary_replace_fdlist_indices_with_handles(v, fdlist)
-        return get_variant(typestring,
-                           array_replace_fdlist_indices_with_handles(
-                               unwrap_variant(v), typestring, fdlist))
-
-    typelist = v.split_signature(v.get_type_string())
-    unwrapped = list(unwrap_variant(v))
-    # pylint: disable=consider-using-enumerate
-    for i, e in enumerate(unwrapped):
-
-        if typelist[i] == 'h':
-            unwrapped[i] = fdlist[unwrapped[i]]
-        elif typelist[i][0] == 'a':
-            unwrapped[i] = array_replace_fdlist_indices_with_handles(
-                e, typelist[i], fdlist)
-        elif typelist[i] == 'v':
-            unwrapped[i] = variant_replace_fdlist_indices_with_handles(
-                e, fdlist)
-        else:
-            nv = get_variant(typelist[i], e)
-            nnv = variant_replace_fdlist_indices_with_handles(nv, fdlist)
-            unwrapped[i] = unwrap_variant(nnv)
-    return get_variant(v.get_type_string(), unwrapped)
+    return UnixFDSwap.apply(v, get_handler)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -24,8 +24,8 @@ from typing import Set
 from dasbus.typing import get_dbus_type, is_base_type, get_native, \
     get_variant, get_variant_type, Int, Int16, Int32, Int64, UInt16, UInt32, \
     UInt64, Bool, Byte, Str, Dict, List, Tuple, Variant, Double, ObjPath, \
-    UnixFD, unwrap_variant, get_type_name, \
-    is_tuple_of_one, get_type_arguments
+    UnixFD, unwrap_variant, get_type_name, is_tuple_of_one, \
+    get_type_arguments, VariantUnpacker, VariantUnwrapper
 
 import gi
 gi.require_version("GLib", "2.0")
@@ -262,9 +262,16 @@ class DBusTypingVariantTests(unittest.TestCase):
         v1 = get_variant(type_hint, value)
         self.assertTrue(isinstance(v1, Variant))
         self.assertEqual(v1.format_string, expected_string)
-        self.assertEqual(v1.unpack(), value)
-        self.assertEqual(unwrap_variant(v1), value)
 
+        # Check unpacking.
+        self.assertEqual(v1.unpack(), value)
+        self.assertEqual(VariantUnpacker.apply(v1), value)
+
+        # Check unwrapping.
+        self.assertEqual(unwrap_variant(v1), value)
+        self.assertEqual(VariantUnwrapper.apply(v1), value)
+
+        # Create a variant from a type string.
         v2 = Variant(expected_string, value)
         self.assertTrue(v2.equal(v1))
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -256,16 +256,21 @@ class DBusTypingTests(unittest.TestCase):
 
 class DBusTypingVariantTests(unittest.TestCase):
 
-    def _test_variant(self, type_hint, expected_string, value):
+    def _test_variant(self, type_hint, expected_string, value,
+                      native_value=None):
         """Create a variant."""
+        # The value is native by default.
+        if native_value is None:
+            native_value = value
+
         # Create a variant from a type hint.
         v1 = get_variant(type_hint, value)
         self.assertTrue(isinstance(v1, Variant))
         self.assertEqual(v1.format_string, expected_string)
 
         # Check unpacking.
-        self.assertEqual(v1.unpack(), value)
-        self.assertEqual(VariantUnpacker.apply(v1), value)
+        self.assertEqual(v1.unpack(), native_value)
+        self.assertEqual(VariantUnpacker.apply(v1), native_value)
 
         # Check unwrapping.
         self.assertEqual(unwrap_variant(v1), value)
@@ -275,9 +280,9 @@ class DBusTypingVariantTests(unittest.TestCase):
         v2 = Variant(expected_string, value)
         self.assertTrue(v2.equal(v1))
 
-        self.assertEqual(get_native(v1), value)
+        self.assertEqual(get_native(v1), native_value)
         self.assertEqual(get_native(v1), get_native(v2))
-        self.assertEqual(get_native(value), value)
+        self.assertEqual(get_native(value), native_value)
 
         # Create a variant from a type string.
         v3 = get_variant(expected_string, value)
@@ -336,6 +341,30 @@ class DBusTypingVariantTests(unittest.TestCase):
 
         self._test_variant(Dict[Str, Int], "a{si}", {"a": 1, "b": 2})
         self._test_variant(Dict[Int, Bool], "a{ib}", {1: True, 2: False})
+
+    def test_variant_variant(self):
+        """Test variants with variant types."""
+        variant = get_variant("i", 1)
+        self._test_variant(Variant, "v", variant, 1)
+
+        variant = get_variant("v", get_variant("i", 1))
+        self._test_variant(Variant, "v", variant, 1)
+
+        variant = get_variant("(b)", (False,))
+        self._test_variant(Variant, "v", variant, (False,))
+
+        variant = get_variant("(v)", (get_variant("b", False),))
+        self._test_variant(Variant, "v", variant, (False,))
+
+        variant = get_variant("ai", [1, 2, 3])
+        self._test_variant(Variant, "v", variant, [1, 2, 3])
+
+        variant = get_variant("av", [
+            get_variant("i", 1),
+            get_variant("i", 2),
+            get_variant("i", 3)
+        ])
+        self._test_variant(Variant, "v", variant, [1, 2, 3])
 
     def test_variant_alias(self):
         """Test variants with type aliases."""


### PR DESCRIPTION
Add classes for unpacking and unwrapping a variant. Move the code to
the `VariantUnpacking`, `VariantUnpacker` and `VariantUnwrapper`
classes. It will allow to reuse the code for other variant modifications.

Use the `UnixFDSwap` class with an appropriate function to swap
the Unix file descriptor with indexes.