### PR TITLE
Don't use pylint from pip on Fedora Rawhide

### DIFF
--- a/.travis/Dockerfile.fedora-rawhide
+++ b/.travis/Dockerfile.fedora-rawhide
@@ -9,11 +9,11 @@ RUN dnf -y update; \
     python3-pip \
     python3-wheel \
     python3-gobject-base \
+    python3-pylint \
     dbus-daemon; \
     dnf clean all
 
 RUN pip3 install \
     sphinx \
     sphinx_rtd_theme \
-    coverage \
-    pylint
+    coverage


### PR DESCRIPTION
Temporarily disable the installation of pylint from pip on Fedora Rawhide.
Use the patched system package that supports Python 3.11.