### PR TITLE
Use pylint from pip on Fedora Rawhide

### DIFF
--- a/.travis/Dockerfile.fedora-rawhide
+++ b/.travis/Dockerfile.fedora-rawhide
@@ -9,11 +9,11 @@ RUN dnf -y update; \
     python3-pip \
     python3-wheel \
     python3-gobject-base \
-    python3-pylint \
     dbus-daemon; \
     dnf clean all
 
 RUN pip3 install \
     sphinx \
     sphinx_rtd_theme \
-    coverage
+    coverage \
+    pylint

--- a/dasbus/typing.py
+++ b/dasbus/typing.py
@@ -256,11 +256,13 @@ class DBusType(object):
     }
 
     # DBus representation of container types.
+    # pylint: disable=unhashable-member
     _container_type_mapping = {
         Tuple:      "(%s)",
         List:       "a%s",
         Dict:       "a{%s}",
     }
+    # pylint: enable=unhashable-member
 
     @staticmethod
     def get_dbus_representation(type_hint):


### PR DESCRIPTION
* Use pylint from pip on Fedora Rawhide.
* Ignore a new false positive found by the latest pylint.