### PR TITLE
UnixFD: Document the support for Unix file descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,28 @@ proxy.GetDevices(callback=callback)
 loop.run()
 ```
 
+Inhibit the system suspend and hibernation.
+
+```python
+import os
+from dasbus.connection import SystemMessageBus
+from dasbus.unix import GLibClientUnix
+bus = SystemMessageBus()
+
+proxy = bus.get_proxy(
+    "org.freedesktop.login1",
+    "/org/freedesktop/login1",
+    client=GLibClientUnix
+)
+
+fd = proxy.Inhibit(
+    "sleep", "my-example", "Running an example", "block"
+)
+
+proxy.ListInhibitors()
+os.close(fd)
+```
+
 Define the org.example.HelloWorld service.
 
 ```python

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -131,6 +131,50 @@ Publish the org.example.HelloWorld service on the session message bus.
     loop = EventLoop()
     loop.run()
 
+Support for Unix file descriptors
+---------------------------------
+
+The support for Unix file descriptors is disabled by default. It needs to be explicitly enabled
+when you create a DBus proxy or publish a DBus object that could send or receive Unix file
+descriptors.
+
+.. warning::
+
+    This functionality is supported only on UNIX.
+
+Send and receive Unix file descriptors with a DBus proxy.
+
+.. code-block:: python
+
+    import os
+    from dasbus.connection import SystemMessageBus
+    from dasbus.unix import GLibClientUnix
+    bus = SystemMessageBus()
+
+    proxy = bus.get_proxy(
+        "org.freedesktop.login1",
+        "/org/freedesktop/login1",
+        client=GLibClientUnix
+    )
+
+    fd = proxy.Inhibit(
+        "sleep", "my-example", "Running an example", "block"
+    )
+
+    proxy.ListInhibitors()
+    os.close(fd)
+
+Allow to send and receive Unix file descriptors within the /org/example/HelloWorld DBus object.
+
+.. code-block:: python
+
+    from dasbus.unix import GLibServerUnix
+    bus.publish_object(
+        "/org/example/HelloWorld",
+        HelloWorld(),
+        server=GLibServerUnix
+    )
+
 Management of DBus names and paths
 ----------------------------------
 

--- a/docs/pydbus.rst
+++ b/docs/pydbus.rst
@@ -11,6 +11,8 @@ What is new
 
 - Support for asynchronous DBus calls: DBus methods can be called asynchronously.
 
+- Support for Unix file descriptors: It is possible to send or receive Unix file descriptors.
+
 - Mapping DBus errors to exceptions: Use Python exceptions to propagate and handle DBus errors.
   Define your own rules for mapping errors to exceptions and back. See the
   :class:`ErrorMapper <dasbus.error.ErrorMapper>` class

--- a/examples/06_inhibit/client.py
+++ b/examples/06_inhibit/client.py
@@ -1,0 +1,37 @@
+#
+# Inhibit the system suspend and hibernation.
+#
+import os
+from dasbus.connection import SystemMessageBus
+from dasbus.unix import GLibClientUnix
+
+if __name__ == "__main__":
+    # Create a representation of a system bus connection.
+    bus = SystemMessageBus()
+
+    # Create a proxy of the /org/freedesktop/login1 object
+    # provided by the org.freedesktop.login1 service with
+    # an enabled support for Unix file descriptors.
+    proxy = bus.get_proxy(
+        "org.freedesktop.login1",
+        "/org/freedesktop/login1",
+        client=GLibClientUnix
+    )
+
+    # Inhibit sleep by this example.
+    print("Inhibit sleep by my-example.")
+    fd = proxy.Inhibit(
+        "sleep",
+        "my-example",
+        "Running an example",
+        "block"
+    )
+
+    # List active inhibitors.
+    print("Active inhibitors:")
+    for inhibitor in sorted(proxy.ListInhibitors()):
+        print("\t".join(map(str, inhibitor)))
+
+    # Release the inhibition lock.
+    print("Release the inhibition lock.")
+    os.close(fd)


### PR DESCRIPTION
* Simplify the README.md file.
* Reorganize and improve documented examples.
* Document the support for Unix file descriptors.
* Add a complete example with Unix file descriptors.