### PR TITLE
Fix bullet point lists

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,8 +10,8 @@ of this effort.
 Requirements
 ____________
 
-* Python 3.6+
-* PyGObject 3
+- Python 3.6+
+- PyGObject 3
 
 You can install `PyGObject <https://pygobject.readthedocs.io>`_ provided by your system or use
 PyPI. The system package is usually called ``python3-gi``, ``python3-gobject`` or ``pygobject3``.
@@ -51,6 +51,6 @@ Or install the RPM package on Fedora 31+.
 Indices and tables
 ==================
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+- :ref:`genindex`
+- :ref:`modindex`
+- :ref:`search`

--- a/docs/pydbus.rst
+++ b/docs/pydbus.rst
@@ -9,81 +9,81 @@ way as pydbus classes.
 What is new
 -----------
 
-* Support for asynchronous DBus calls: DBus methods can be called asynchronously.
+- Support for asynchronous DBus calls: DBus methods can be called asynchronously.
 
-* Mapping DBus errors to exceptions: Use Python exceptions to propagate and handle DBus errors.
+- Mapping DBus errors to exceptions: Use Python exceptions to propagate and handle DBus errors.
   Define your own rules for mapping errors to exceptions and back. See the
   :class:`ErrorMapper <dasbus.error.ErrorMapper>` class
 
-* Support for type hints: Use Python type hints from :mod:`dasbus.typing` to define DBus types.
+- Support for type hints: Use Python type hints from :mod:`dasbus.typing` to define DBus types.
 
-* Generating XML specifications: Automatically generate XML specifications from Python classes
+- Generating XML specifications: Automatically generate XML specifications from Python classes
   with the :func:`dbus_interface <dasbus.server.interface.dbus_interface>` decorator.
 
-* Support for DBus structures: Represent DBus structures (dictionaries of variants) by Python
+- Support for DBus structures: Represent DBus structures (dictionaries of variants) by Python
   objects. See the :class:`DBusData <dasbus.structure.DBusData>` class.
 
-* Support for groups of DBus objects: Use DBus containers from :mod:`dasbus.server.container`
+- Support for groups of DBus objects: Use DBus containers from :mod:`dasbus.server.container`
   to publish groups of Python objects.
 
-* Composition over inheritance: The library follows the principle of composition over
+- Composition over inheritance: The library follows the principle of composition over
   inheritance. It allows to easily change the default behaviour.
 
-* Lazy DBus connections: DBus connections are established on demand.
+- Lazy DBus connections: DBus connections are established on demand.
 
-* Lazy DBus proxies: Attributes of DBus proxies are created on demand.
+- Lazy DBus proxies: Attributes of DBus proxies are created on demand.
 
 
 What is different
 -----------------
 
-* No context managers: There are no context managers in dasbus. Context managers and event
+- No context managers: There are no context managers in dasbus. Context managers and event
   loops don't work very well together.
 
-* No auto-completion: There is no support for automatic completion of DBus names and paths.
+- No auto-completion: There is no support for automatic completion of DBus names and paths.
   We recommend to work with constants defined by classes from :mod:`dasbus.identifier`
   instead of strings.
 
-* No unpacking of variants: The dasbus library doesn't unpack variants by default. It means
+- No unpacking of variants: The dasbus library doesn't unpack variants by default. It means
   that values received from DBus match the types declared in the XML specification. Use the
   :func:`get_native <dasbus.typing.get_native>` function to unpack the values.
 
-* Obtaining proxy objects: Call the :meth:`get_proxy <dasbus.connection.MessageBus.get_proxy>`
+- Obtaining proxy objects: Call the :meth:`get_proxy <dasbus.connection.MessageBus.get_proxy>`
   method to get a proxy of the specified DBus object.
 
-* No single-interface view: DBus proxies don't support single-interface views. Use the
+- No single-interface view: DBus proxies don't support single-interface views. Use the
   :class:`InterfaceProxy <dasbus.client.proxy.InterfaceProxy>` class to access a specific
   interface of a DBus object.
 
-* Higher priority of standard interfaces: If there is a DBus interface in the XML specification
+- Higher priority of standard interfaces: If there is a DBus interface in the XML specification
   that redefines a member of a standard interface, the DBus proxy will choose a member of the
   standard interface. Use the :class:`InterfaceProxy <dasbus.client.proxy.InterfaceProxy>` class
   to access a specific interface of a DBus object.
 
-* No support for help: Members of DBus proxies are created lazily, so the build-in ``help``
+- No support for help: Members of DBus proxies are created lazily, so the build-in ``help``
   function doesn't return useful information about the DBus interfaces.
 
-* Watching DBus names: Use :class:`a service observer <dasbus.client.observer.DBusObserver>`
+- Watching DBus names: Use :class:`a service observer <dasbus.client.observer.DBusObserver>`
   to watch a DBus name.
 
-* Acquiring DBus names: Call the :meth:`register_service <dasbus.connection.MessageBus.register_service>`
+- Acquiring DBus names: Call the :meth:`register_service <dasbus.connection.MessageBus.register_service>`
   method to acquire a DBus name.
 
-* Providing XML specifications: Use the ``__dbus_xml__`` attribute to provide the XML
+- Providing XML specifications: Use the ``__dbus_xml__`` attribute to provide the XML
   specification of a DBus object. Or you can generate it from the code using the
   :func:`dbus_interface <dasbus.server.interface.dbus_interface>` decorator.
 
-* No support for polkit: There is no support for the DBus service ``org.freedesktop.PolicyKit1``.
+- No support for polkit: There is no support for the DBus service ``org.freedesktop.PolicyKit1``.
 
 What is the same (for now)
 --------------------------
 
-* No support for other event loops: Dasbus uses GLib as its backend, so it requires to use
+- No support for other event loops: Dasbus uses GLib as its backend, so it requires to use
   the GLib event loop. However, the GLib part of dasbus is separated from the rest of the code,
   so it shouldn't be too difficult to add support for a different backend. It would be necessary
   to replace :class:`dasbus.typing.Variant` and :class:`dasbus.typing.VariantType` with their
   abstractions and reorganize the code.
 
-* No support for org.freedesktop.DBus.ObjectManager: There is no support for object managers,
+- No support for org.freedesktop.DBus.ObjectManager: There is no support for object managers,
   however the :class:`DBus containers <dasbus.server.container.DBusContainer>` could be a good
   starting point.


### PR DESCRIPTION
The bullet point lists are not present if they are marked with `*`, because there is a bug in the docs tooling.
Let's use the standard `-` symbol instead of hunting down docs package versions.