### PR TITLE
Improve the installation instruction

### DIFF
--- a/.travis/Dockerfile.centos
+++ b/.travis/Dockerfile.centos
@@ -4,14 +4,14 @@ ENV LANG=C.utf8
 
 RUN cat /etc/os-release
 
-RUN yum -y update && \
-    yum -y install \
+RUN dnf -y update && \
+    dnf -y install \
     make \
     python3 \
     python3-pip \
     python3-gobject-base \
     dbus-daemon \
-    && yum clean all
+    && dnf clean all
 
 RUN pip3 install \
     sphinx \

--- a/README.md
+++ b/README.md
@@ -16,34 +16,37 @@ a result of this effort.
 * Python 3.6+
 * PyGObject 3
 
-You can install [PyGObject](https://pygobject.readthedocs.io) provided by your system or use PyPI.
-The system package is usually called `python3-gi`, `python3-gobject` or `pygobject3`. See the
-[instructions](https://pygobject.readthedocs.io/en/latest/getting_started.html) for your platform
-(only for PyGObject, you don't need cairo or GTK).
+You can install [PyGObject](https://pygobject.readthedocs.io) provided by your operating system
+or use PyPI. The system package is usually called `python3-gi`, `python3-gobject` or `pygobject3`.
+See the [instructions](https://pygobject.readthedocs.io/en/latest/getting_started.html) for
+your platform (only for PyGObject, you don't need cairo or GTK).
 
 The library is known to work with Python 3.8, PyGObject 3.34 and GLib 2.63, but these are not the
 required minimal versions.
 
 ## Installation
 
-Install the package from [PyPI](https://pypi.org/project/dasbus/). Follow the instructions above
-to install the required dependencies.
+Install the package from [PyPI](https://pypi.org/project/dasbus/) or install the package
+provided by your operating system if available.
+
+### Install from PyPI
+
+Follow the instructions above to install the requirements before you install `dasbus` with `pip`.
+The required dependencies has to be installed manually in this case.
 
 ```
 pip3 install dasbus
 ```
 
-Or install the RPM package on Fedora 31+.
+### Install the system package
 
-```
-sudo dnf install python3-dasbus
-```
+Follow the instructions for your operating system to install the `python-dasbus` package.
+The required dependencies should be installed automatically by the system package manager.
 
-Or install the DEB package on Ubuntu 22.04+ and Debian 11+.
-
-```
-sudo apt install python3-dasbus
-```
+* [Arch Linux](https://dasbus.readthedocs.io/en/latest/#install-on-arch-linux)
+* [Debian / Ubuntu](https://dasbus.readthedocs.io/en/latest/#install-on-debian-ubuntu)
+* [Fedora / CentOS / RHEL](https://dasbus.readthedocs.io/en/latest/#install-on-fedora-centos-rhel)
+* [openSUSE](https://dasbus.readthedocs.io/en/latest/#install-on-opensuse)
 
 ## Examples
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,35 +8,74 @@ it with our own solution because its upstream development stalled. The dasbus li
 of this effort.
 
 Requirements
-____________
+------------
 
 - Python 3.6+
 - PyGObject 3
 
-You can install `PyGObject <https://pygobject.readthedocs.io>`_ provided by your system or use
-PyPI. The system package is usually called ``python3-gi``, ``python3-gobject`` or ``pygobject3``.
-See the `instructions <https://pygobject.readthedocs.io/en/latest/getting_started.html>`_ for
-your platform (only for PyGObject, you don't need cairo or GTK).
+You can install `PyGObject <https://pygobject.readthedocs.io>`_ provided by your operating system
+or use PyPI. The system package is usually called ``python3-gi``, ``python3-gobject`` or
+``pygobject3``. See the `instructions <https://pygobject.readthedocs.io/en/latest/getting_started.html>`_
+for your platform (only for PyGObject, you don't need cairo or GTK).
 
 The library is known to work with Python 3.8, PyGObject 3.34 and GLib 2.63, but these are not the
 required minimal versions.
 
+
 Installation
 ------------
 
-Install the package from `PyPI <https://pypi.org/project/dasbus/>`_. Follow the instructions above
-to install the required dependencies.
+Install the package from `PyPI <https://pypi.org/project/dasbus/>`_ or install the package
+provided by your operating system if available.
+
+Install from PyPI
+^^^^^^^^^^^^^^^^^
+
+Follow the instructions above to install the requirements before you install ``dasbus`` with
+``pip``. The required dependencies has to be installed manually in this case.
 
 ::
 
     pip3 install dasbus
 
+Install on Arch Linux
+^^^^^^^^^^^^^^^^^^^^^
 
-Or install the RPM package on Fedora 31+.
+Build and install the community package from the `Arch User Repository <https://aur.archlinux.org/>`_.
+Follow the `guidelines <https://wiki.archlinux.org/title/Arch_User_Repository>`_.
+
+::
+
+    git clone https://aur.archlinux.org/python-dasbus.git
+    cd python-dasbus
+    makepkg -si
+
+Install on Debian / Ubuntu
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Install the system package on Debian 11+ or Ubuntu 22.04+.
+
+::
+
+    sudo apt install python3-dasbus
+
+Install on Fedora / CentOS / RHEL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Install the system package on Fedora 31+, CentOS Stream 8+ or RHEL 8+.
 
 ::
 
     sudo dnf install python3-dasbus
+
+Install on openSUSE
+^^^^^^^^^^^^^^^^^^^
+
+Install the system package on openSUSE Tumbleweed or openSUSE Leap 15.2+.
+
+::
+
+    sudo zypper install python3-dasbus
 
 
 .. toctree::
@@ -49,7 +88,7 @@ Or install the RPM package on Fedora 31+.
    Examples <examples>
 
 Indices and tables
-==================
+------------------
 
 - :ref:`genindex`
 - :ref:`modindex`


### PR DESCRIPTION
* Clean up the installation documentation in the `README.md` file.
* Add steps for all operating systems that provide the `dasbus` package.