### PR TITLE
CI: Fix the failing tests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -504,5 +504,5 @@ valid-metaclass-classmethod-first-arg=cls
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/.travis/Dockerfile.centos
+++ b/.travis/Dockerfile.centos
@@ -1,6 +1,6 @@
 ARG TAG=stream9
 FROM quay.io/centos/centos:${TAG}
-ENV LANG=C.utf8
+ENV LC_CTYPE=C.UTF-8
 
 RUN cat /etc/os-release
 

--- a/.travis/Dockerfile.debian
+++ b/.travis/Dockerfile.debian
@@ -1,6 +1,6 @@
 ARG TAG=latest
 FROM debian:${TAG}
-ENV LANG=C.utf8
+ENV LC_CTYPE=C.UTF-8
 
 RUN cat /etc/os-release
 

--- a/.travis/Dockerfile.fedora
+++ b/.travis/Dockerfile.fedora
@@ -1,6 +1,6 @@
 ARG TAG=rawhide
 FROM registry.fedoraproject.org/fedora:${TAG}
-ENV LANG=C.utf8
+ENV LC_CTYPE=C.UTF-8
 
 RUN cat /etc/os-release
 

--- a/.travis/Dockerfile.python
+++ b/.travis/Dockerfile.python
@@ -1,6 +1,6 @@
 ARG TAG=latest
 FROM python:${TAG}
-ENV LANG=C.utf8
+ENV LC_CTYPE=C.UTF-8
 
 RUN cat /etc/os-release
 

--- a/.travis/Dockerfile.ubuntu
+++ b/.travis/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 ARG TAG=devel
 FROM ubuntu:${TAG}
-ENV LANG=C.utf8
+ENV LC_CTYPE=C.UTF-8
 
 # Disable interaction with tzdata.
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.travis/Dockerfile.ubuntu
+++ b/.travis/Dockerfile.ubuntu
@@ -17,6 +17,11 @@ RUN apt-get update && \
     dbus-daemon \
     && rm -rf /var/lib/apt/lists/*
 
+# Don't use the externally managed environment.
+RUN python3 -m venv --system-site-packages /opt/venv
+ENV VIRTUAL_ENV="/opt/venv"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
 COPY requirements.txt .
 
 RUN pip3 install -U pip && \


### PR DESCRIPTION
* Fix the Pylint warnings about the `overgeneral-exceptions` option.
* Fix locale settings in testing containers.
* Don't use the externally managed environment on Ubuntu.